### PR TITLE
Make the sdk client global for mocks

### DIFF
--- a/pkg/elfparser/elf.go
+++ b/pkg/elfparser/elf.go
@@ -59,7 +59,7 @@ type BpfData struct {
 	Maps    map[string]ebpf_maps.BpfMap // List of associated maps
 }
 
-type bpfSDKClient struct {
+type BpfSDKClient struct {
 	mapApi  ebpf_maps.BpfMapAPIs
 	progApi ebpf_progs.BpfProgAPIs
 }
@@ -90,18 +90,18 @@ type elfLoader struct {
 	progSectionMap map[uint32]progEntry
 }
 
-func New() *bpfSDKClient {
-	return &bpfSDKClient{
+func New() *BpfSDKClient {
+	return &BpfSDKClient{
 		mapApi:  &ebpf_maps.BpfMap{},
 		progApi: &ebpf_progs.BpfProgram{},
 	}
 }
 
-var _ AWSeBpfSdkAPIs = (*bpfSDKClient)(nil)
+var _ AWSeBpfSdkAPIs = (*BpfSDKClient)(nil)
 
 // This is not needed 5.11 kernel onwards because per-cgroup mem limits
 // https://lore.kernel.org/bpf/20201201215900.3569844-1-guro@fb.com/
-func (b *bpfSDKClient) IncreaseRlimit() error {
+func (b *BpfSDKClient) IncreaseRlimit() error {
 	err := unix.Setrlimit(unix.RLIMIT_MEMLOCK, &unix.Rlimit{Cur: unix.RLIM_INFINITY, Max: unix.RLIM_INFINITY})
 	if err != nil {
 		log.Infof("Failed to bump up the rlimit")
@@ -122,7 +122,7 @@ func newElfLoader(elfFile *elf.File, bpfmapapi ebpf_maps.BpfMapAPIs, bpfprogapi 
 	return elfloader
 }
 
-func (b *bpfSDKClient) LoadBpfFile(path, customizedPinPath string) (map[string]BpfData, map[string]ebpf_maps.BpfMap, error) {
+func (b *BpfSDKClient) LoadBpfFile(path, customizedPinPath string) (map[string]BpfData, map[string]ebpf_maps.BpfMap, error) {
 	bpfFile, err := os.Open(path)
 	if err != nil {
 		log.Infof("LoadBpfFile failed to open")
@@ -669,7 +669,7 @@ func IsMapGlobal(pinPath string) bool {
 	return true
 }
 
-func (b *bpfSDKClient) RecoverGlobalMaps() (map[string]ebpf_maps.BpfMap, error) {
+func (b *BpfSDKClient) RecoverGlobalMaps() (map[string]ebpf_maps.BpfMap, error) {
 	_, err := os.Stat(constdef.BPF_DIR_MNT)
 	if err != nil {
 		log.Infof("BPF FS director is not present")
@@ -737,7 +737,7 @@ func (b *bpfSDKClient) RecoverGlobalMaps() (map[string]ebpf_maps.BpfMap, error) 
 	return loadedGlobalMaps, nil
 }
 
-func (b *bpfSDKClient) RecoverAllBpfProgramsAndMaps() (map[string]BpfData, error) {
+func (b *BpfSDKClient) RecoverAllBpfProgramsAndMaps() (map[string]BpfData, error) {
 	_, err := os.Stat(constdef.BPF_DIR_MNT)
 	if err != nil {
 		log.Infof("BPF FS directory is not present")

--- a/pkg/elfparser/mocks/elfparser_mocks.go
+++ b/pkg/elfparser/mocks/elfparser_mocks.go
@@ -50,9 +50,9 @@ func (mr *MockAWSeBpfSdkAPIsMockRecorder) IncreaseRlimit() *gomock.Call {
 }
 
 // LoadBpfFile mocks base method.
-func (m *MockAWSeBpfSdkAPIs) LoadBpfFile(arg0 string) (map[string]elfparser.BpfData, map[string]maps.BpfMap, error) {
+func (m *MockAWSeBpfSdkAPIs) LoadBpfFile(arg0, arg1 string) (map[string]elfparser.BpfData, map[string]maps.BpfMap, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LoadBpfFile", arg0)
+	ret := m.ctrl.Call(m, "LoadBpfFile", arg0, arg1)
 	ret0, _ := ret[0].(map[string]elfparser.BpfData)
 	ret1, _ := ret[1].(map[string]maps.BpfMap)
 	ret2, _ := ret[2].(error)
@@ -60,9 +60,9 @@ func (m *MockAWSeBpfSdkAPIs) LoadBpfFile(arg0 string) (map[string]elfparser.BpfD
 }
 
 // LoadBpfFile indicates an expected call of LoadBpfFile.
-func (mr *MockAWSeBpfSdkAPIsMockRecorder) LoadBpfFile(arg0 interface{}) *gomock.Call {
+func (mr *MockAWSeBpfSdkAPIsMockRecorder) LoadBpfFile(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadBpfFile", reflect.TypeOf((*MockAWSeBpfSdkAPIs)(nil).LoadBpfFile), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadBpfFile", reflect.TypeOf((*MockAWSeBpfSdkAPIs)(nil).LoadBpfFile), arg0, arg1)
 }
 
 // RecoverAllBpfProgramsAndMaps mocks base method.


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Keep the SDK client global so that external clients can use mocks..


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
