### PR TITLE
makefile: fix to remove unused option from build-bpf target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,34 +32,20 @@ vet:    ## Run go vet on source code.
 # Build BPF
 CLANG := clang
 CLANG_INCLUDE := -I../../..
-EBPF_SOURCE := test-data/tc.ingress.bpf.c
-EBPF_BINARY := test-data/tc.ingress.bpf.elf
-EBPF_TEST_SOURCE := test-data/tc.bpf.c
-EBPF_TEST_BINARY := test-data/tc.bpf.elf 
-EBPF_TEST_MAP_SOURCE := test-data/test.map.bpf.c
-EBPF_TEST_MAP_BINARY := test-data/test.map.bpf.elf
-EBPF_TEST_LIC_SOURCE := test-data/test_license.bpf.c
-EBPF_TEST_LIC_BINARY := test-data/test_license.bpf.elf
-EBPF_TEST_INV_MAP_SOURCE := test-data/invalid_map.bpf.c
-EBPF_TEST_INV_MAP_BINARY := test-data/invalid_map.bpf.elf
-EBPF_TEST_RECOVERY_SOURCE := test-data/recoverydata.bpf.c
-EBPF_TEST_RECOVERY_BINARY := test-data/recoverydata.bpf.elf
-EBPF_TEST_KPROBE_SOURCE := test-data/test-kprobe.bpf.c
-EBPF_TEST_KPROBE_BINARY := test-data/test-kprobe.bpf.elf    
-EBPF_TEST_XDP_SOURCE := test-data/xdp.bpf.c
-EBPF_TEST_XDP_BINARY := test-data/xdp.bpf.elf  
-EBPF_TEST_RINGBUFFER_SOURCE := test-data/ring_buffer.bpf.c
-EBPF_TEST_RINGBUFFER_BINARY := test-data/ring_buffer.bpf.elf  
-build-bpf: ## Build BPF
-	$(CLANG) $(CLANG_INCLUDE) -g -O2 -Wall -fpie -target bpf -DCORE -D__BPF_TRACING__ -D__TARGET_ARCH_$(ARCH) -c $(EBPF_SOURCE) -o $(EBPF_BINARY)
-	$(CLANG) $(CLANG_INCLUDE) -g -O2 -Wall -fpie -target bpf -DCORE -D__BPF_TRACING__ -D__TARGET_ARCH_$(ARCH) -c $(EBPF_TEST_SOURCE) -o $(EBPF_TEST_BINARY)
-	$(CLANG) $(CLANG_INCLUDE) -g -O2 -Wall -fpie -target bpf -DCORE -D__BPF_TRACING__ -D__TARGET_ARCH_$(ARCH) -c $(EBPF_TEST_MAP_SOURCE) -o $(EBPF_TEST_MAP_BINARY)
-	$(CLANG) $(CLANG_INCLUDE) -g -O2 -Wall -fpie -target bpf -DCORE -D__BPF_TRACING__ -D__TARGET_ARCH_$(ARCH) -c $(EBPF_TEST_LIC_SOURCE) -o $(EBPF_TEST_LIC_BINARY)
-	$(CLANG) $(CLANG_INCLUDE) -g -O2 -Wall -fpie -target bpf -DCORE -D__BPF_TRACING__ -D__TARGET_ARCH_$(ARCH) -c $(EBPF_TEST_INV_MAP_SOURCE) -o $(EBPF_TEST_INV_MAP_BINARY)
-	$(CLANG) $(CLANG_INCLUDE) -g -O2 -Wall -fpie -target bpf -DCORE -D__BPF_TRACING__ -D__TARGET_ARCH_$(ARCH) -c $(EBPF_TEST_RECOVERY_SOURCE) -o $(EBPF_TEST_RECOVERY_BINARY)
-	$(CLANG) $(CLANG_INCLUDE) -g -O2 -Wall -fpie -target bpf -DCORE -D__BPF_TRACING__ -D__TARGET_ARCH_$(ARCH) -c $(EBPF_TEST_KPROBE_SOURCE) -o $(EBPF_TEST_KPROBE_BINARY)
-	$(CLANG) $(CLANG_INCLUDE) -g -O2 -Wall -fpie -target bpf -DCORE -D__BPF_TRACING__ -D__TARGET_ARCH_$(ARCH) -c $(EBPF_TEST_XDP_SOURCE) -o $(EBPF_TEST_XDP_BINARY)
-	$(CLANG) $(CLANG_INCLUDE) -g -O2 -Wall -fpie -target bpf -DCORE -D__BPF_TRACING__ -D__TARGET_ARCH_$(ARCH) -c $(EBPF_TEST_RINGBUFFER_SOURCE) -o $(EBPF_TEST_RINGBUFFER_BINARY)
+BPF_CFLAGS := -g -O2 -Wall -fpie -target bpf -DCORE -D__BPF_TRACING__ -D__TARGET_ARCH_$(ARCH) 
+TARGETS := \
+		  test-data/tc.ingress \
+		  test-data/tc \
+		  test-data/test.map \
+		  test-data/test_license \
+		  test-data/invalid_map \
+		  test-data/recoverydata \
+		  test-data/test-kprobe \
+		  test-data/xdp \
+		  test-data/ring_buffer
+
+%.bpf.elf: %.bpf.c
+	$(CLANG) $(CLANG_INCLUDE) $(BPF_CFLAGS) -c $< -o $@
 
 vmlinuxh:
 	bpftool btf dump file /sys/kernel/btf/vmlinux format c > $(abspath ./test-data/vmlinux.h)
@@ -67,7 +53,11 @@ vmlinuxh:
 ##@ Run Unit Tests
 # Run unit tests
 unit-test: vmlinuxh
-unit-test: build-bpf
+unit-test: $(addsuffix .bpf.elf,$(TARGETS))
 unit-test: export AWS_EBPF_SDK_LOG_FILE=stdout
 unit-test:    ## Run unit tests
 	go test -v -coverprofile=coverage.txt -covermode=atomic ./pkg/...
+
+.PHONY: clean
+clean:
+	-@rm -f test-data/*.elf

--- a/Makefile
+++ b/Makefile
@@ -51,15 +51,15 @@ EBPF_TEST_XDP_BINARY := test-data/xdp.bpf.elf
 EBPF_TEST_RINGBUFFER_SOURCE := test-data/ring_buffer.bpf.c
 EBPF_TEST_RINGBUFFER_BINARY := test-data/ring_buffer.bpf.elf  
 build-bpf: ## Build BPF
-	$(CLANG) $(CLANG_INCLUDE) -g -O2 -Wall -fpie -target bpf -DCORE -D__BPF_TRACING__ -march=bpf -D__TARGET_ARCH_$(ARCH) -c $(EBPF_SOURCE) -o $(EBPF_BINARY)
-	$(CLANG) $(CLANG_INCLUDE) -g -O2 -Wall -fpie -target bpf -DCORE -D__BPF_TRACING__ -march=bpf -D__TARGET_ARCH_$(ARCH) -c $(EBPF_TEST_SOURCE) -o $(EBPF_TEST_BINARY)
-	$(CLANG) $(CLANG_INCLUDE) -g -O2 -Wall -fpie -target bpf -DCORE -D__BPF_TRACING__ -march=bpf -D__TARGET_ARCH_$(ARCH) -c $(EBPF_TEST_MAP_SOURCE) -o $(EBPF_TEST_MAP_BINARY)
-	$(CLANG) $(CLANG_INCLUDE) -g -O2 -Wall -fpie -target bpf -DCORE -D__BPF_TRACING__ -march=bpf -D__TARGET_ARCH_$(ARCH) -c $(EBPF_TEST_LIC_SOURCE) -o $(EBPF_TEST_LIC_BINARY)
-	$(CLANG) $(CLANG_INCLUDE) -g -O2 -Wall -fpie -target bpf -DCORE -D__BPF_TRACING__ -march=bpf -D__TARGET_ARCH_$(ARCH) -c $(EBPF_TEST_INV_MAP_SOURCE) -o $(EBPF_TEST_INV_MAP_BINARY)
-	$(CLANG) $(CLANG_INCLUDE) -g -O2 -Wall -fpie -target bpf -DCORE -D__BPF_TRACING__ -march=bpf -D__TARGET_ARCH_$(ARCH) -c $(EBPF_TEST_RECOVERY_SOURCE) -o $(EBPF_TEST_RECOVERY_BINARY)
-	$(CLANG) $(CLANG_INCLUDE) -g -O2 -Wall -fpie -target bpf -DCORE -D__BPF_TRACING__ -march=bpf -D__TARGET_ARCH_$(ARCH) -c $(EBPF_TEST_KPROBE_SOURCE) -o $(EBPF_TEST_KPROBE_BINARY)
-	$(CLANG) $(CLANG_INCLUDE) -g -O2 -Wall -fpie -target bpf -DCORE -D__BPF_TRACING__ -march=bpf -D__TARGET_ARCH_$(ARCH) -c $(EBPF_TEST_XDP_SOURCE) -o $(EBPF_TEST_XDP_BINARY)
-	$(CLANG) $(CLANG_INCLUDE) -g -O2 -Wall -fpie -target bpf -DCORE -D__BPF_TRACING__ -march=bpf -D__TARGET_ARCH_$(ARCH) -c $(EBPF_TEST_RINGBUFFER_SOURCE) -o $(EBPF_TEST_RINGBUFFER_BINARY)
+	$(CLANG) $(CLANG_INCLUDE) -g -O2 -Wall -fpie -target bpf -DCORE -D__BPF_TRACING__ -D__TARGET_ARCH_$(ARCH) -c $(EBPF_SOURCE) -o $(EBPF_BINARY)
+	$(CLANG) $(CLANG_INCLUDE) -g -O2 -Wall -fpie -target bpf -DCORE -D__BPF_TRACING__ -D__TARGET_ARCH_$(ARCH) -c $(EBPF_TEST_SOURCE) -o $(EBPF_TEST_BINARY)
+	$(CLANG) $(CLANG_INCLUDE) -g -O2 -Wall -fpie -target bpf -DCORE -D__BPF_TRACING__ -D__TARGET_ARCH_$(ARCH) -c $(EBPF_TEST_MAP_SOURCE) -o $(EBPF_TEST_MAP_BINARY)
+	$(CLANG) $(CLANG_INCLUDE) -g -O2 -Wall -fpie -target bpf -DCORE -D__BPF_TRACING__ -D__TARGET_ARCH_$(ARCH) -c $(EBPF_TEST_LIC_SOURCE) -o $(EBPF_TEST_LIC_BINARY)
+	$(CLANG) $(CLANG_INCLUDE) -g -O2 -Wall -fpie -target bpf -DCORE -D__BPF_TRACING__ -D__TARGET_ARCH_$(ARCH) -c $(EBPF_TEST_INV_MAP_SOURCE) -o $(EBPF_TEST_INV_MAP_BINARY)
+	$(CLANG) $(CLANG_INCLUDE) -g -O2 -Wall -fpie -target bpf -DCORE -D__BPF_TRACING__ -D__TARGET_ARCH_$(ARCH) -c $(EBPF_TEST_RECOVERY_SOURCE) -o $(EBPF_TEST_RECOVERY_BINARY)
+	$(CLANG) $(CLANG_INCLUDE) -g -O2 -Wall -fpie -target bpf -DCORE -D__BPF_TRACING__ -D__TARGET_ARCH_$(ARCH) -c $(EBPF_TEST_KPROBE_SOURCE) -o $(EBPF_TEST_KPROBE_BINARY)
+	$(CLANG) $(CLANG_INCLUDE) -g -O2 -Wall -fpie -target bpf -DCORE -D__BPF_TRACING__ -D__TARGET_ARCH_$(ARCH) -c $(EBPF_TEST_XDP_SOURCE) -o $(EBPF_TEST_XDP_BINARY)
+	$(CLANG) $(CLANG_INCLUDE) -g -O2 -Wall -fpie -target bpf -DCORE -D__BPF_TRACING__ -D__TARGET_ARCH_$(ARCH) -c $(EBPF_TEST_RINGBUFFER_SOURCE) -o $(EBPF_TEST_RINGBUFFER_BINARY)
 
 vmlinuxh:
 	bpftool btf dump file /sys/kernel/btf/vmlinux format c > $(abspath ./test-data/vmlinux.h)


### PR DESCRIPTION
This patch removes the unused `-march` option from the command to build the ELF file. 
For compiling a BPF file, the `march` option is not needed.

````shellsession
clang -I../../.. -g -O2 -Wall -fpie -target bpf -DCORE -D__BPF_TRACING__ -march=bpf -D__TARGET_ARCH_x86 -c test-data/tc.ingress.bpf.c -o test-data/tc.ingress.bpf.elf
clang-16: warning: argument unused during compilation: '-march=bpf' [-Wunused-command-line-argument]
````
