### PR TITLE
test-data: fix to solve compile warning for test-data

### DIFF
--- a/test-data/recoverydata.bpf.c
+++ b/test-data/recoverydata.bpf.c
@@ -96,7 +96,7 @@ int conn_del(struct pt_regs *ctx) {
 }
 
 SEC("tracepoint/sched/sched_process_fork")
-int sched_process_fork(struct sched_process_fork_t *ctx) {
+int sched_process_fork(void *ctx) {
     return 0;
 }
 

--- a/test-data/tc.ingress.bpf.c
+++ b/test-data/tc.ingress.bpf.c
@@ -119,7 +119,7 @@ int conn_del(struct pt_regs *ctx) {
 }
 
 SEC("tracepoint/sched/sched_process_fork")
-int sched_process_fork(struct sched_process_fork_t *ctx) {
+int sched_process_fork(void *ctx) {
     return 0;
 }
 


### PR DESCRIPTION
This patch adds the common header that includes missing struct to resolve the following compile warnings for resolvedata and tc.ingress.

```shellsesson
 doas make test-data/recoverydata.bpf.elf
clang -I../../.. -g -O2 -Wall -fpie -target bpf -DCORE -D__BPF_TRACING__ -D__TARGET_ARCH_x86  -c test-data/recoverydata.bpf.c -o test-data/recoverydata.bpf.elf
test-data/recoverydata.bpf.c:101:31: warning: declaration of 'struct sched_process_fork_t' will not be visible outside of this function [-Wvisibility]
int sched_process_fork(struct sched_process_fork_t *ctx) {
                              ^
1 warning generated.
```

Signed-off-by: shun159 <dreamdiagnosis@gmail.com>