### PR TITLE
kprobe: Add defer statements for resource cleanup in KprobeAttach()/KretprobeAttach()

### DIFF
--- a/pkg/kprobe/kprobe.go
+++ b/pkg/kprobe/kprobe.go
@@ -87,6 +87,7 @@ func (k *bpfKprobe) KprobeAttach() error {
 		log.Errorf("error opening kprobe_events file: %v", err)
 		return err
 	}
+	defer file.Close()
 
 	eventString := fmt.Sprintf("p:kprobes/%s %s", k.eventName, k.funcName)
 	_, err = file.WriteString(eventString)
@@ -173,6 +174,7 @@ func (k *bpfKprobe) KretprobeAttach() error {
 		log.Errorf("error opening kprobe_events file: %v", err)
 		return err
 	}
+	defer file.Close()
 
 	eventString := fmt.Sprintf("r4096:kretprobes/%s %s", k.eventName, k.funcName)
 	_, err = file.WriteString(eventString)


### PR DESCRIPTION
Ensure that file handle is properly closed using defer statements.