### PR TITLE
Fix verifier log buffer size

### DIFF
--- a/pkg/progs/loader.go
+++ b/pkg/progs/loader.go
@@ -211,12 +211,12 @@ func (m *BpfProgram) LoadProg(progMetaData CreateEBPFProgInput) (int, error) {
 		prog_type = uint32(netlink.BPF_PROG_TYPE_UNSPEC)
 	}
 
-	logBuf := make([]byte, 65535)
+	logBuf := make([]byte, utils.GetLogBufferSize())
 	program := netlink.BPFAttr{
 		ProgType: prog_type,
 		LogBuf:   uintptr(unsafe.Pointer(&logBuf[0])),
 		LogSize:  uint32(cap(logBuf) - 1),
-		LogLevel: 4,
+		LogLevel: 1,
 	}
 
 	program.Insns = uintptr(unsafe.Pointer(&progMetaData.ProgData[0]))

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -17,6 +17,7 @@ package utils
 import (
 	"encoding/binary"
 	"fmt"
+	"math"
 	"os"
 	"runtime"
 	"syscall"
@@ -193,4 +194,8 @@ func Unmount_bpf_fs() error {
 		fmt.Println("error unmounting bpffs")
 	}
 	return err
+}
+
+func GetLogBufferSize() int {
+	return math.MaxUint32 >> 8
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
As the program size increases we need to make sure the log buffer that verifiers fills should be sufficient enough. If not verifier returns EINVAL.

https://github.com/torvalds/linux/blob/v5.10/kernel/bpf/verifier.c#L11862

So setting the value to be inline with libbpf

https://github.com/libbpf/libbpf/blob/e26b84dc330c9644c07428c271ab491b0f01f4e1/src/bpf.h#L118

```
#define BPF_LOG_BUF_SIZE (UINT32_MAX >> 8) /* verifier maximum in kernels <= 5.1 */
```

```
===========================================================
                   TESTING SUMMARY
===========================================================
                   TestCase|Result
              Test loading TC filter|SUCCESS
   Test loading Maps without Program|SUCCESS
         Test loading Map operations|SUCCESS
                Test loading Program|SUCCESS
             Test loading V6 Program|SUCCESS
===========================================================
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
