### PR TITLE
Fix: nil pointer exception on `utils.IsfileExists`

### DIFF
--- a/pkg/maps/loader.go
+++ b/pkg/maps/loader.go
@@ -229,7 +229,11 @@ func (m *BpfMap) PinMap(pinPath string, pinType uint32) error {
 	if pinType == constdef.PIN_GLOBAL_NS.Index() {
 
 		//If pinPath is already present lets delete and create a new one
-		if utils.IsfileExists(pinPath) {
+		found, err := utils.IsfileExists(pinPath)
+		if err != nil {
+			return fmt.Errorf("unable to check file: %w", err)
+		}
+		if found {
 			log.Infof("Found file %s so deleting the path", pinPath)
 			err := utils.UnPinObject(pinPath)
 			if err != nil {
@@ -237,7 +241,7 @@ func (m *BpfMap) PinMap(pinPath string, pinType uint32) error {
 				return err
 			}
 		}
-		err := os.MkdirAll(filepath.Dir(pinPath), 0755)
+		err = os.MkdirAll(filepath.Dir(pinPath), 0755)
 		if err != nil {
 			log.Errorf("error creating directory %s: %v", filepath.Dir(pinPath), err)
 			return fmt.Errorf("error creating directory %s: %v", filepath.Dir(pinPath), err)

--- a/pkg/progs/loader.go
+++ b/pkg/progs/loader.go
@@ -143,9 +143,11 @@ func MountBpfFS() error {
 }
 
 func (m *BpfProgram) PinProg(progFD uint32, pinPath string) error {
-
-	var err error
-	if utils.IsfileExists(pinPath) {
+	found, err := utils.IsfileExists(pinPath)
+	if err != nil {
+		return fmt.Errorf("unable to check file: %w", err)
+	}
+	if found {
 		log.Infof("Found file %s so deleting the path", pinPath)
 		err = utils.UnPinObject(pinPath)
 		if err != nil {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -16,7 +16,9 @@ package utils
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
+	"io/fs"
 	"math"
 	"os"
 	"runtime"
@@ -83,11 +85,17 @@ func PinObject(objFD uint32, pinPath string) error {
 }
 
 func IsfileExists(fname string) bool {
+	log := logger.Get()
 	info, err := os.Stat(fname)
-	if os.IsNotExist(err) {
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
 		return false
+	case err != nil:
+		log.Errorf("Error while checking file %s: %v", fname, err)
+		return false
+	default:
+		return !info.IsDir()
 	}
-	return !info.IsDir()
 }
 
 func UnPinObject(pinPath string) error {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -16,7 +16,9 @@ package utils
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
+	"io/fs"
 	"math"
 	"os"
 	"runtime"
@@ -85,7 +87,7 @@ func PinObject(objFD uint32, pinPath string) error {
 func IsfileExists(fname string) (bool, error) {
 	info, err := os.Stat(fname)
 	switch {
-	case os.IsNotExist(err):
+	case errors.Is(err, fs.ErrNotExist):
 		return false, nil
 	case err != nil:
 		return false, fmt.Errorf("unexpected error stat %q: %w", fname, err)


### PR DESCRIPTION
Fixes https://github.com/aws/aws-ebpf-sdk-go/issues/71

*Description of changes:*

Handle other type of errors beyond ErrNotExist.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
