### PR TITLE
Validate the interface name against a list of prefixes

### DIFF
--- a/test/main.go
+++ b/test/main.go
@@ -297,7 +297,7 @@ func TestLoadTCfilter() error {
 	tcProg := progInfo["/sys/fs/bpf/globals/aws/programs/test_handle_ingress"].Program
 	progFD := tcProg.ProgFD
 
-	gosdkTcClient := ebpf_tc.New("lo")
+	gosdkTcClient := ebpf_tc.New([]string{"lo"})
 
 	fmt.Println("Try Attach ingress probe")
 	err = gosdkTcClient.TCIngressAttach("lo", int(progFD), "ingress_test")


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This accepts a list of interface prefixes to TC class. If the interface doesn't start from any of the accepted list of prefixes we return an error and skip any actions on that interface

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
