### PR TITLE
fix: zero fd field before close in UnPinMap and UnPinProg

### DIFF
--- a/pkg/maps/loader.go
+++ b/pkg/maps/loader.go
@@ -272,10 +272,17 @@ func (m *BpfMap) UnPinMap(pinPath string) error {
 		return err
 	}
 	if m.MapFD <= 0 {
-		log.Errorf("map FD is invalid or closed %d", m.MapFD)
+		log.Debugf("map FD is invalid or already closed %d", m.MapFD)
 		return nil
 	}
-	return unix.Close(int(m.MapFD))
+	// Zero MapFD before closing so a second call to UnPinMap on the same struct
+	// is a no-op instead of closing a fd the kernel has since reassigned to an
+	// unrelated open file in the same process. Without this, callers that retain
+	// the BpfMap reference (e.g. agents that cache map handles across reconciles)
+	// can corrupt arbitrary file descriptors held elsewhere in the process.
+	fd := m.MapFD
+	m.MapFD = 0
+	return unix.Close(int(fd))
 }
 
 func (m *BpfMap) CreateMapEntry(key, value uintptr) error {

--- a/pkg/progs/loader.go
+++ b/pkg/progs/loader.go
@@ -181,10 +181,16 @@ func (m *BpfProgram) UnPinProg(pinPath string) error {
 		return err
 	}
 	if m.ProgFD <= 0 {
-		log.Errorf("map FD is invalid or closed %d", m.ProgFD)
+		log.Debugf("prog FD is invalid or already closed %d", m.ProgFD)
 		return nil
 	}
-	return unix.Close(int(m.ProgFD))
+	// Zero ProgFD before closing so a second call to UnPinProg on the same struct
+	// is a no-op instead of closing a fd the kernel has since reassigned to an
+	// unrelated open file in the same process. See pkg/maps/loader.go UnPinMap
+	// for the equivalent fix on BpfMap.
+	fd := m.ProgFD
+	m.ProgFD = 0
+	return unix.Close(fd)
 }
 
 func parseLogs(log []byte) []string {


### PR DESCRIPTION
*Issue #, if available:*

Related to [aws/aws-network-policy-agent#484](https://github.com/aws/aws-network-policy-agent/issues/484) ("bad file descriptor" surfacing on `bpf(BPF_MAP_UPDATE_ELEM)`); both that issue and the symptom below trace back to the same double-close pattern in this SDK.

*Description of changes:*

`BpfMap.UnPinMap` and `BpfProgram.UnPinProg` call `unix.Close` on `m.MapFD` / `m.ProgFD` without clearing the field afterwards. A second call on the same struct re-closes the same integer fd, and after the first close the kernel is free to reassign that fd number to any other open file in the process, so the second close silently invalidates an unrelated fd.

This PR captures the fd in a local, zeroes the struct field, then calls `unix.Close`. `UnPinMap` and `UnPinProg` become idempotent and can no longer corrupt unrelated file descriptors.

### Code change

In ` + "`pkg/maps/loader.go`" + `:

```go
-	if m.MapFD <= 0 {
-		log.Errorf("map FD is invalid or closed %d", m.MapFD)
-		return nil
-	}
-	return unix.Close(int(m.MapFD))
+	if m.MapFD <= 0 {
+		log.Debugf("map FD is invalid or already closed %d", m.MapFD)
+		return nil
+	}
+	// Zero MapFD before closing so a second call to UnPinMap on the same struct
+	// is a no-op instead of closing a fd the kernel has since reassigned to an
+	// unrelated open file in the same process. Without this, callers that retain
+	// the BpfMap reference (e.g. agents that cache map handles across reconciles)
+	// can corrupt arbitrary file descriptors held elsewhere in the process.
+	fd := m.MapFD
+	m.MapFD = 0
+	return unix.Close(int(fd))
```

Same shape in ` + "`pkg/progs/loader.go`" + ` for `UnPinProg` (also fixes a small log-message typo: `"map FD is invalid"` -> `"prog FD is invalid"` in that function). The `log.Errorf` is demoted to `log.Debugf` because the early-return is now a normal idempotent path, not an error condition.

### How the bug surfaces in practice

This was observed in production running `aws-network-policy-agent v1.3.1` (which holds `BpfMap` structs for namespaced maps `cp_ingress_map`, `cp_egress_map`, `ipcache_map` across reconciles). On each reconcile, `UnPinMap` closed the stored `MapFD` again. Eventually one of those re-close calls landed on a fd number the kernel had reassigned to the lumberjack-managed log file opened by the agent's zap `WriteSyncer`. After that, every zap log call from the agent returned `*os.PathError{Op:"write", Path:"/var/log/aws-routed-eni/<file>.log", Err:EBADF}` and zap's internal-error fallback at `go.uber.org/zap@v1.27.0/zapcore/entry.go:256`

```go
fmt.Fprintf(ce.ErrorOutput, "%v write error: %v\n", ce.Time, err)
```

emitted

```
<time> write error: write /var/log/aws-routed-eni/<file>.log: bad file descriptor
```

to stderr on every entry. One node produced ~32M of those lines in 24 hours (~371/s steady state). Restarting the pod cleared the bad-fd state, but a fresh pod hit the same loop on the next reconcile cycle.

The same EBADF class is also visible in [aws/aws-network-policy-agent#484](https://github.com/aws/aws-network-policy-agent/issues/484), where it surfaces on the next `bpf(BPF_MAP_UPDATE_ELEM)` syscall instead of on a log file write.

### Testing

- ` + "`GOOS=linux go build ./pkg/maps/... ./pkg/progs/...`" + ` passes.
- ` + "`GOOS=linux go vet ./pkg/maps/... ./pkg/progs/...`" + ` passes.
- Behavior change is confined to `UnPinMap` / `UnPinProg`: first call still closes the underlying fd and reports any `Close` error to the caller; subsequent calls become a Debug-level no-op. No callers in this repo or in `aws-network-policy-agent` rely on `UnPinMap` returning an error for the "already closed" case.

### Risks

Low. The change adds a single assignment (`m.MapFD = 0`) before the existing `unix.Close`. It is strictly safer than the current behavior for any caller that may end up invoking `UnPinMap` / `UnPinProg` twice on the same struct.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.