### PR TITLE
parameterized the Namespace map config in SDK

### DIFF
--- a/pkg/elfparser/elf.go
+++ b/pkg/elfparser/elf.go
@@ -46,6 +46,13 @@ var (
 
 var log = logger.Get()
 var sdkCache = cache.Get()
+var namespacedMaps map[string]struct{}
+
+// Config carries SDK construction options. NamespacedMaps lists BPF map names
+// that should be treated as per-namespace (per-pod-identifier) rather than global
+type Config struct {
+	NamespacedMaps []string
+}
 
 type BpfSDKClient interface {
 	IncreaseRlimit() error
@@ -98,7 +105,11 @@ type elfLoader struct {
 	progSectionMap map[uint32]progEntry
 }
 
-func New() BpfSDKClient {
+func New(cfg Config) BpfSDKClient {
+	namespacedMaps = make(map[string]struct{}, len(cfg.NamespacedMaps))
+	for _, m := range cfg.NamespacedMaps {
+		namespacedMaps[m] = struct{}{}
+	}
 	return &bpfSDKClient{
 		mapApi:  &ebpf_maps.BpfMap{},
 		progApi: &ebpf_progs.BpfProgram{},
@@ -688,12 +699,8 @@ func (e *elfLoader) doLoadELF(inputData BpfCustomData) (map[string]BpfData, map[
 }
 
 func isNamespacedMap(mapName string) bool {
-	switch mapName {
-	case "ingress_map", "egress_map", "ingress_pod_state_map", "egress_pod_state_map", "cp_ingress_map", "cp_egress_map", "ipcache_map":
-		return true
-	default:
-		return false
-	}
+	_, ok := namespacedMaps[mapName]
+	return ok
 }
 
 func GetMapNameFromBPFPinPath(pinPath string) (string, string) {

--- a/pkg/elfparser/elf_test.go
+++ b/pkg/elfparser/elf_test.go
@@ -33,6 +33,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var testNamespacedMaps = []string{
+	"ingress_map", "egress_map", "ingress_pod_state_map",
+	"egress_pod_state_map", "cp_ingress_map", "cp_egress_map", "ipcache_map",
+}
+
 var (
 	MAP_SECTION_INDEX = 8
 	MAP_TYPE_1        = int(constdef.BPF_MAP_TYPE_LRU_HASH.Index())
@@ -537,7 +542,7 @@ func TestRecovery(t *testing.T) {
 			m := setup(t, tt.elfFileName)
 			defer m.ctrl.Finish()
 
-			bpfSDKclient := New()
+			bpfSDKclient := New(Config{NamespacedMaps: testNamespacedMaps})
 
 			if tt.recoverGlobal {
 				_, _, err := bpfSDKclient.LoadBpfFile(m.path, "global")
@@ -592,6 +597,7 @@ func TestGetMapNameFromBPFPinPath(t *testing.T) {
 			want: [2]string{"egress_map", "hello-udp-748dc8d996-default"},
 		},
 	}
+	_ = New(Config{NamespacedMaps: testNamespacedMaps})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got1, got2 := GetMapNameFromBPFPinPath(tt.args.pinPath)
@@ -633,6 +639,7 @@ func TestMapGlobal(t *testing.T) {
 			want: true,
 		},
 	}
+	_ = New(Config{NamespacedMaps: testNamespacedMaps})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := IsMapGlobal(tt.args.pinPath)

--- a/pkg/kprobe/kprobe_test.go
+++ b/pkg/kprobe/kprobe_test.go
@@ -66,7 +66,7 @@ func TestTCKprobeAttachDetach(t *testing.T) {
 	m.ebpf_progs.EXPECT().GetProgFromPinPath(gomock.Any()).AnyTimes()
 	m.ebpf_progs.EXPECT().GetBPFProgAssociatedMapsIDs(gomock.Any()).AnyTimes()
 
-	bpfSDKclient := elfparser.New()
+	bpfSDKclient := elfparser.New(elfparser.Config{})
 	progInfo, _, err := bpfSDKclient.LoadBpfFile(m.path, DUMMY_PROG_NAME)
 	if err != nil {
 		assert.NoError(t, err)
@@ -105,7 +105,7 @@ func TestTCKretprobeAttachDetach(t *testing.T) {
 	m.ebpf_progs.EXPECT().GetProgFromPinPath(gomock.Any()).AnyTimes()
 	m.ebpf_progs.EXPECT().GetBPFProgAssociatedMapsIDs(gomock.Any()).AnyTimes()
 
-	bpfSDKclient := elfparser.New()
+	bpfSDKclient := elfparser.New(elfparser.Config{})
 	progInfo, _, err := bpfSDKclient.LoadBpfFile(m.path, DUMMY_PROG_NAME)
 	if err != nil {
 		assert.NoError(t, err)

--- a/pkg/tc/tc_test.go
+++ b/pkg/tc/tc_test.go
@@ -157,7 +157,7 @@ func TestTCIngressAttachDetach(t *testing.T) {
 	m.ebpf_progs.EXPECT().GetProgFromPinPath(gomock.Any()).AnyTimes()
 	m.ebpf_progs.EXPECT().GetBPFProgAssociatedMapsIDs(gomock.Any()).AnyTimes()
 
-	bpfSDKclient := elfparser.New()
+	bpfSDKclient := elfparser.New(elfparser.Config{})
 	progInfo, _, err := bpfSDKclient.LoadBpfFile(m.path, DUMMY_PROG_NAME)
 	if err != nil {
 		assert.NoError(t, err)
@@ -197,7 +197,7 @@ func TestTCEgressAttachDetach(t *testing.T) {
 	m.ebpf_progs.EXPECT().GetProgFromPinPath(gomock.Any()).AnyTimes()
 	m.ebpf_progs.EXPECT().GetBPFProgAssociatedMapsIDs(gomock.Any()).AnyTimes()
 
-	bpfSDKclient := elfparser.New()
+	bpfSDKclient := elfparser.New(elfparser.Config{})
 	progInfo, _, err := bpfSDKclient.LoadBpfFile(m.path, DUMMY_PROG_NAME)
 	if err != nil {
 		assert.NoError(t, err)
@@ -240,7 +240,7 @@ func TestQdiscCleanup(t *testing.T) {
 	m.ebpf_progs.EXPECT().GetProgFromPinPath(gomock.Any()).AnyTimes()
 	m.ebpf_progs.EXPECT().GetBPFProgAssociatedMapsIDs(gomock.Any()).AnyTimes()
 
-	bpfSDKclient := elfparser.New()
+	bpfSDKclient := elfparser.New(elfparser.Config{})
 	progInfo, _, err := bpfSDKclient.LoadBpfFile(m.path, DUMMY_PROG_NAME)
 	if err != nil {
 		assert.NoError(t, err)
@@ -304,7 +304,7 @@ func TestNetLinkAPIs(t *testing.T) {
 			m.ebpf_progs.EXPECT().GetProgFromPinPath(gomock.Any()).AnyTimes()
 			m.ebpf_progs.EXPECT().GetBPFProgAssociatedMapsIDs(gomock.Any()).AnyTimes()
 
-			bpfSDKclient := elfparser.New()
+			bpfSDKclient := elfparser.New(elfparser.Config{})
 			_, _, err := bpfSDKclient.LoadBpfFile(m.path, DUMMY_PROG_NAME)
 			if err != nil {
 				assert.NoError(t, err)

--- a/pkg/xdp/xdp_test.go
+++ b/pkg/xdp/xdp_test.go
@@ -112,7 +112,7 @@ func TestTCXdpAttachDetach(t *testing.T) {
 	m.ebpf_progs.EXPECT().GetProgFromPinPath(gomock.Any()).AnyTimes()
 	m.ebpf_progs.EXPECT().GetBPFProgAssociatedMapsIDs(gomock.Any()).AnyTimes()
 
-	bpfSDKclient := elfparser.New()
+	bpfSDKclient := elfparser.New(elfparser.Config{})
 	progInfo, _, err := bpfSDKclient.LoadBpfFile(m.path, DUMMY_PROG_PREFIX)
 	if err != nil {
 		assert.NoError(t, err)
@@ -181,7 +181,7 @@ func TestNetLinkAPIs(t *testing.T) {
 			m.ebpf_progs.EXPECT().GetProgFromPinPath(gomock.Any()).AnyTimes()
 			m.ebpf_progs.EXPECT().GetBPFProgAssociatedMapsIDs(gomock.Any()).AnyTimes()
 
-			bpfSDKclient := elfparser.New()
+			bpfSDKclient := elfparser.New(elfparser.Config{})
 			progInfo, _, err := bpfSDKclient.LoadBpfFile(m.path, DUMMY_PROG_PREFIX)
 			if err != nil {
 				assert.NoError(t, err)

--- a/test/main.go
+++ b/test/main.go
@@ -103,7 +103,7 @@ func main() {
 }
 
 func TestLoadProg() error {
-	gosdkClient := goelf.New()
+	gosdkClient := goelf.New(goelf.Config{})
 	progInfo, _, err := gosdkClient.LoadBpfFile("c/test.bpf.elf", "test")
 	if err != nil {
 		fmt.Println("Load BPF failed", "err:", err)
@@ -117,7 +117,7 @@ func TestLoadProg() error {
 }
 
 func TestLoadv6Prog() error {
-	gosdkClient := goelf.New()
+	gosdkClient := goelf.New(goelf.Config{})
 	progInfo, _, err := gosdkClient.LoadBpfFile("c/test-v6.bpf.elf", "test")
 	if err != nil {
 		fmt.Println("Load BPF failed", "err:", err)
@@ -131,7 +131,7 @@ func TestLoadv6Prog() error {
 }
 
 func TestLoadMapWithNoProg() error {
-	gosdkClient := goelf.New()
+	gosdkClient := goelf.New(goelf.Config{})
 	_, loadedMap, err := gosdkClient.LoadBpfFile("c/test-map.bpf.elf", "test")
 	if err != nil {
 		fmt.Println("Load BPF failed", "err:", err)
@@ -146,7 +146,7 @@ func TestLoadMapWithNoProg() error {
 }
 
 func TestMapOperations() error {
-	gosdkClient := goelf.New()
+	gosdkClient := goelf.New(goelf.Config{})
 	_, loadedMap, err := gosdkClient.LoadBpfFile("c/test-map.bpf.elf", "operations")
 	if err != nil {
 		fmt.Println("Load BPF failed", "err:", err)
@@ -283,7 +283,7 @@ func TestMapOperations() error {
 }
 
 func TestLoadTCfilter() error {
-	gosdkClient := goelf.New()
+	gosdkClient := goelf.New(goelf.Config{})
 	progInfo, _, err := gosdkClient.LoadBpfFile("c/test.bpf.elf", "test")
 	if err != nil {
 		fmt.Println("Load BPF failed", "err:", err)
@@ -323,7 +323,7 @@ func TestLoadTCfilter() error {
 }
 
 func TestLoadMapWithCustomSize() error {
-	gosdkClient := goelf.New()
+	gosdkClient := goelf.New(goelf.Config{})
 
 	var customData goelf.BpfCustomData
 	customData.FilePath = "c/test-map.bpf.elf"
@@ -346,7 +346,7 @@ func TestLoadMapWithCustomSize() error {
 }
 
 func TestBulkMapOperations() error {
-	gosdkClient := goelf.New()
+	gosdkClient := goelf.New(goelf.Config{})
 	_, loadedMap, err := gosdkClient.LoadBpfFile("c/test-map.bpf.elf", "operations")
 	if err != nil {
 		fmt.Println("Load BPF failed", "err:", err)
@@ -432,7 +432,7 @@ func bpfInetTrieKeyToIPNet(key BPFInetTrieKey) net.IPNet {
 }
 
 func TestBulkRefreshMapOperations() error {
-	gosdkClient := goelf.New()
+	gosdkClient := goelf.New(goelf.Config{})
 	_, loadedMap, err := gosdkClient.LoadBpfFile("c/test-map.bpf.elf", "operations")
 	if err != nil {
 		fmt.Println("Load BPF failed", "err:", err)


### PR DESCRIPTION
Description of changes:

  Problem: Namespaced map names hardcoded inside SDK (isNamespacedMap switch on ingress_map, egress_map, ingress_pod_state_map, egress_pod_state_map, cp_ingress_map, cp_egress_map, ipcache_map). Tight coupling
  between SDK and consumer (network-policy-agent). Any consumer adding/renaming a per-namespace map requires SDK change + version bump. SDK version drift risks regressions — consumer maps silently treated as global
  if SDK list lags, or vice versa.

  Fix: Move list to consumer via constructor config.

  - Add elfparser.Config struct with NamespacedMaps []string.
  - elfparser.New() → elfparser.New(cfg Config). Config populates package-level set consumed by isNamespacedMap.
  - isNamespacedMap switch replaced with set lookup.

  Result: Consumers own their namespaced map list. SDK version bumps no longer risk regressing namespacing semantics.


> NOTE - Made intentional chose to modify constructs as this map naming is already coupled strongly to NPA use-case and don't expect any breakage. If anyone does use this SDK, they can just pass empty config and it should work for those consumers. Another reason to change constructor is to have compile time signal 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
