### PR TITLE
refactor code to scope functions to bpfSDKClient and elfLoader

### DIFF
--- a/pkg/elfparser/elf.go
+++ b/pkg/elfparser/elf.go
@@ -46,7 +46,6 @@ var (
 
 var log = logger.Get()
 var sdkCache = cache.Get()
-var namespacedMaps map[string]struct{}
 
 // Config carries SDK construction options. NamespacedMaps lists BPF map names
 // that should be treated as per-namespace (per-pod-identifier) rather than global
@@ -74,7 +73,14 @@ type BpfCustomData struct {
 	CustomMapSize map[string]int // Map of bpfMaps with custom size
 }
 
+// mapClassifier classifies BPF pin paths as global vs per-namespace using the
+// configured set of namespaced map names.
+type mapClassifier struct {
+	namespacedMaps map[string]struct{}
+}
+
 type bpfSDKClient struct {
+	mapClassifier
 	mapApi  ebpf_maps.BpfMapAPIs
 	progApi ebpf_progs.BpfProgAPIs
 }
@@ -92,6 +98,7 @@ type progEntry struct {
 }
 
 type elfLoader struct {
+	mapClassifier
 	elfFile           *elf.File
 	customizedPinPath string
 	bpfMapApi         ebpf_maps.BpfMapAPIs
@@ -106,13 +113,14 @@ type elfLoader struct {
 }
 
 func New(cfg Config) BpfSDKClient {
-	namespacedMaps = make(map[string]struct{}, len(cfg.NamespacedMaps))
+	nsSet := make(map[string]struct{}, len(cfg.NamespacedMaps))
 	for _, m := range cfg.NamespacedMaps {
-		namespacedMaps[m] = struct{}{}
+		nsSet[m] = struct{}{}
 	}
 	return &bpfSDKClient{
-		mapApi:  &ebpf_maps.BpfMap{},
-		progApi: &ebpf_progs.BpfProgram{},
+		mapClassifier: mapClassifier{namespacedMaps: nsSet},
+		mapApi:        &ebpf_maps.BpfMap{},
+		progApi:       &ebpf_progs.BpfProgram{},
 	}
 }
 
@@ -129,8 +137,9 @@ func (b *bpfSDKClient) IncreaseRlimit() error {
 	return nil
 }
 
-func newElfLoader(elfFile *elf.File, bpfmapapi ebpf_maps.BpfMapAPIs, bpfprogapi ebpf_progs.BpfProgAPIs, customizedpinPath string) *elfLoader {
+func newElfLoader(elfFile *elf.File, bpfmapapi ebpf_maps.BpfMapAPIs, bpfprogapi ebpf_progs.BpfProgAPIs, customizedpinPath string, namespacedMaps map[string]struct{}) *elfLoader {
 	elfloader := &elfLoader{
+		mapClassifier:     mapClassifier{namespacedMaps: namespacedMaps},
 		elfFile:           elfFile,
 		bpfMapApi:         bpfmapapi,
 		bpfProgApi:        bpfprogapi,
@@ -155,7 +164,7 @@ func (b *bpfSDKClient) LoadBpfFile(path, customizedPinPath string) (map[string]B
 		return nil, nil, err
 	}
 
-	elfLoader := newElfLoader(elfFile, b.mapApi, b.progApi, customizedPinPath)
+	elfLoader := newElfLoader(elfFile, b.mapApi, b.progApi, customizedPinPath, b.namespacedMaps)
 
 	bpfLoadedProg, bpfLoadedMaps, err := elfLoader.doLoadELF(BpfCustomData{})
 	if err != nil {
@@ -178,7 +187,7 @@ func (b *bpfSDKClient) LoadBpfFileWithCustomData(inputData BpfCustomData) (map[s
 		return nil, nil, err
 	}
 
-	elfLoader := newElfLoader(elfFile, b.mapApi, b.progApi, inputData.CustomPinPath)
+	elfLoader := newElfLoader(elfFile, b.mapApi, b.progApi, inputData.CustomPinPath, b.namespacedMaps)
 
 	bpfLoadedProg, bpfLoadedMaps, err := elfLoader.doLoadELF(inputData)
 	if err != nil {
@@ -229,7 +238,7 @@ func (e *elfLoader) loadMap(parsedMapData []ebpf_maps.CreateEBPFMapInput) (map[s
 
 		programmedMaps[loadedMaps.Name] = bpfMap
 
-		if IsMapGlobal(pinPath) {
+		if e.IsMapGlobal(pinPath) {
 			//Add to global cache
 			sdkCache.Set(loadedMaps.Name, int(bpfMap.MapFD))
 			log.Infof("Added map Name %s and FD %d to SDK cache", loadedMaps.Name, bpfMap.MapFD)
@@ -698,18 +707,18 @@ func (e *elfLoader) doLoadELF(inputData BpfCustomData) (map[string]BpfData, map[
 	return loadedProgData, loadedMapData, nil
 }
 
-func isNamespacedMap(mapName string) bool {
-	_, ok := namespacedMaps[mapName]
+func (m *mapClassifier) isNamespacedMap(mapName string) bool {
+	_, ok := m.namespacedMaps[mapName]
 	return ok
 }
 
-func GetMapNameFromBPFPinPath(pinPath string) (string, string) {
+func (m *mapClassifier) GetMapNameFromBPFPinPath(pinPath string) (string, string) {
 	splittedPinPath := strings.Split(pinPath, "/")
 	lastSegment := splittedPinPath[len(splittedPinPath)-1]
 	mapNamespace, mapName, _ := strings.Cut(lastSegment, "_")
 	log.Infof("Found Identified - %s : %s", mapNamespace, mapName)
 
-	if isNamespacedMap(mapName) {
+	if m.isNamespacedMap(mapName) {
 		log.Infof("Adding %s -> %s", mapName, mapNamespace)
 		return mapName, mapNamespace
 	}
@@ -718,9 +727,9 @@ func GetMapNameFromBPFPinPath(pinPath string) (string, string) {
 	return mapName, mapName
 }
 
-func IsMapGlobal(pinPath string) bool {
-	mapName, _ := GetMapNameFromBPFPinPath(pinPath)
-	return !isNamespacedMap(mapName)
+func (m *mapClassifier) IsMapGlobal(pinPath string) bool {
+	mapName, _ := m.GetMapNameFromBPFPinPath(pinPath)
+	return !m.isNamespacedMap(mapName)
 }
 
 func (b *bpfSDKClient) RecoverGlobalMaps() (map[string]ebpf_maps.BpfMap, error) {
@@ -738,7 +747,7 @@ func (b *bpfSDKClient) RecoverGlobalMaps() (map[string]ebpf_maps.BpfMap, error) 
 			}
 			if !fsinfo.IsDir() {
 				log.Infof("Dumping pinpaths - ", pinPath)
-				if IsMapGlobal(pinPath) {
+				if b.IsMapGlobal(pinPath) {
 					log.Infof("Found global pinpaths - ", pinPath)
 					bpfMapInfo, err := b.mapApi.GetMapFromPinPath(pinPath)
 					if err != nil {
@@ -749,7 +758,7 @@ func (b *bpfSDKClient) RecoverGlobalMaps() (map[string]ebpf_maps.BpfMap, error) 
 					log.Infof("Got ID %d", mapID)
 
 					//Get map name
-					mapName, _ := GetMapNameFromBPFPinPath(pinPath)
+					mapName, _ := b.GetMapNameFromBPFPinPath(pinPath)
 
 					log.Infof("Adding ID %d to name %s", mapID, mapName)
 
@@ -835,10 +844,10 @@ func (b *bpfSDKClient) RecoverAllBpfProgramsAndMaps() (map[string]BpfData, error
 					mapID := bpfMapInfo.Id
 					log.Infof("Got ID %d", mapID)
 					//Get map name
-					mapName, mapNamespace := GetMapNameFromBPFPinPath(pinPath)
+					mapName, mapNamespace := b.GetMapNameFromBPFPinPath(pinPath)
 					mapIDsToNames[int(mapID)] = mapName
 
-					if IsMapGlobal(pinPath) {
+					if b.IsMapGlobal(pinPath) {
 						return nil
 					}
 					//Fill New FD since old FDs will be deleted on recovery
@@ -1006,7 +1015,7 @@ func (b *bpfSDKClient) GetAllBpfProgramsAndMaps() (map[string]BpfData, error) {
 					mapID := bpfMapInfo.Id
 					log.Infof("Got ID %d", mapID)
 					//Get map name
-					mapName, mapNamespace := GetMapNameFromBPFPinPath(pinPath)
+					mapName, mapNamespace := b.GetMapNameFromBPFPinPath(pinPath)
 					mapIDsToNames[int(mapID)] = mapName
 
 					log.Infof("Adding ID %d to name %s and NS %s", mapID, mapName, mapNamespace)

--- a/pkg/elfparser/elf_test.go
+++ b/pkg/elfparser/elf_test.go
@@ -108,7 +108,7 @@ func TestLoad(t *testing.T) {
 
 			elfFile, err := elf.NewFile(f)
 			assert.NoError(t, err)
-			elfLoader := newElfLoader(elfFile, m.ebpf_maps, m.ebpf_progs, "test")
+			elfLoader := newElfLoader(elfFile, m.ebpf_maps, m.ebpf_progs, "test", nil)
 			loadedProgs, loadedMaps, err := elfLoader.doLoadELF(BpfCustomData{})
 			assert.NoError(t, err)
 			assert.Equal(t, tt.wantProg, len(loadedProgs))
@@ -148,7 +148,7 @@ func TestParseSection(t *testing.T) {
 
 			elfFile, err := elf.NewFile(f)
 			assert.NoError(t, err)
-			elfLoader := newElfLoader(elfFile, m.ebpf_maps, m.ebpf_progs, "test")
+			elfLoader := newElfLoader(elfFile, m.ebpf_maps, m.ebpf_progs, "test", nil)
 
 			err = elfLoader.parseSection()
 			if tt.wantErr != nil {
@@ -190,7 +190,7 @@ func TestParseSection(t *testing.T) {
 
 			elfFile, err := elf.NewFile(f)
 			assert.NoError(t, err)
-			elfLoader := newElfLoader(elfFile, m.ebpf_maps, m.ebpf_progs, "test")
+			elfLoader := newElfLoader(elfFile, m.ebpf_maps, m.ebpf_progs, "test", nil)
 
 			err = elfLoader.parseSection()
 			if tt.wantErr != nil {
@@ -231,7 +231,7 @@ func TestParseSection(t *testing.T) {
 
 			elfFile, err := elf.NewFile(f)
 			assert.NoError(t, err)
-			elfLoader := newElfLoader(elfFile, m.ebpf_maps, m.ebpf_progs, "test")
+			elfLoader := newElfLoader(elfFile, m.ebpf_maps, m.ebpf_progs, "test", nil)
 
 			err = elfLoader.parseSection()
 			if tt.wantErr != nil {
@@ -281,7 +281,7 @@ func TestParseSection(t *testing.T) {
 
 			elfFile, err := elf.NewFile(f)
 			assert.NoError(t, err)
-			elfLoader := newElfLoader(elfFile, m.ebpf_maps, m.ebpf_progs, "test")
+			elfLoader := newElfLoader(elfFile, m.ebpf_maps, m.ebpf_progs, "test", nil)
 
 			err = elfLoader.parseSection()
 			if tt.wantErr != nil {
@@ -338,7 +338,7 @@ func TestParseMap(t *testing.T) {
 
 			elfFile, err := elf.NewFile(f)
 			assert.NoError(t, err)
-			elfLoader := newElfLoader(elfFile, m.ebpf_maps, m.ebpf_progs, "test")
+			elfLoader := newElfLoader(elfFile, m.ebpf_maps, m.ebpf_progs, "test", nil)
 
 			err = elfLoader.parseSection()
 			assert.NoError(t, err)
@@ -386,7 +386,7 @@ func TestParseMap(t *testing.T) {
 			var parsedMapData []int
 			elfFile, err := elf.NewFile(f)
 			assert.NoError(t, err)
-			elfLoader := newElfLoader(elfFile, m.ebpf_maps, m.ebpf_progs, "test")
+			elfLoader := newElfLoader(elfFile, m.ebpf_maps, m.ebpf_progs, "test", nil)
 
 			err = elfLoader.parseSection()
 			assert.NoError(t, err)
@@ -459,7 +459,7 @@ func TestParseProg(t *testing.T) {
 
 			elfFile, err := elf.NewFile(f)
 			assert.NoError(t, err)
-			elfLoader := newElfLoader(elfFile, m.ebpf_maps, m.ebpf_progs, "test")
+			elfLoader := newElfLoader(elfFile, m.ebpf_maps, m.ebpf_progs, "test", nil)
 
 			err = elfLoader.parseSection()
 			assert.NoError(t, err)
@@ -597,10 +597,10 @@ func TestGetMapNameFromBPFPinPath(t *testing.T) {
 			want: [2]string{"egress_map", "hello-udp-748dc8d996-default"},
 		},
 	}
-	_ = New(Config{NamespacedMaps: testNamespacedMaps})
+	client := New(Config{NamespacedMaps: testNamespacedMaps}).(*bpfSDKClient)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got1, got2 := GetMapNameFromBPFPinPath(tt.args.pinPath)
+			got1, got2 := client.GetMapNameFromBPFPinPath(tt.args.pinPath)
 			assert.Equal(t, tt.want[0], got1)
 			assert.Equal(t, tt.want[1], got2)
 		})
@@ -639,13 +639,39 @@ func TestMapGlobal(t *testing.T) {
 			want: true,
 		},
 	}
-	_ = New(Config{NamespacedMaps: testNamespacedMaps})
+	client := New(Config{NamespacedMaps: testNamespacedMaps}).(*bpfSDKClient)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := IsMapGlobal(tt.args.pinPath)
+			got := client.IsMapGlobal(tt.args.pinPath)
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestMapClassifier(t *testing.T) {
+	mc := mapClassifier{
+		namespacedMaps: map[string]struct{}{
+			"ingress_map": {},
+			"egress_map":  {},
+		},
+	}
+
+	assert.True(t, mc.isNamespacedMap("ingress_map"))
+	assert.False(t, mc.isNamespacedMap("policy_events"))
+
+	name, ns := mc.GetMapNameFromBPFPinPath("/sys/fs/bpf/globals/aws/maps/pod-abc-default_ingress_map")
+	assert.Equal(t, "ingress_map", name)
+	assert.Equal(t, "pod-abc-default", ns)
+
+	name, ns = mc.GetMapNameFromBPFPinPath("/sys/fs/bpf/globals/aws/maps/global_policy_events")
+	assert.Equal(t, "policy_events", name)
+	assert.Equal(t, "policy_events", ns)
+
+	assert.False(t, mc.IsMapGlobal("/sys/fs/bpf/globals/aws/maps/pod-abc-default_ingress_map"))
+	assert.True(t, mc.IsMapGlobal("/sys/fs/bpf/globals/aws/maps/global_policy_events"))
+
+	empty := mapClassifier{namespacedMaps: map[string]struct{}{}}
+	assert.True(t, empty.IsMapGlobal("/sys/fs/bpf/globals/aws/maps/pod-abc-default_ingress_map"))
 }
 
 func TestProgType(t *testing.T) {


### PR DESCRIPTION
this change is refactoring code to scope functions to bpfSDKClient and elfLoader And avoid usage to public methods, since namespace map source will be passed by client to SDK

*Issue #, if available:*

addressing comments from https://github.com/aws/aws-ebpf-sdk-go/pull/148

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
