### PR TITLE
Retrying prog load when thread gets interupted during the process

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,56 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package metrics exposes process-wide observability counters for the SDK.
+//
+// The counters are plain atomics rather than prometheus metrics so the SDK
+// stays free of a metrics-library dependency. Consumers (e.g. the network
+// policy agent) read them via the getters here and register them against their
+// own prometheus registry (such as controller-runtime's).
+package metrics
+
+import "sync/atomic"
+
+var (
+	// progLoadEAGAINRetries counts individual BPF_PROG_LOAD attempts that
+	// returned EAGAIN and were retried. A single load may contribute more than
+	// one retry, so this is an attempt count, not a load count.
+	progLoadEAGAINRetries atomic.Uint64
+	// progLoadEAGAINExhausted counts BPF_PROG_LOAD calls that returned EAGAIN on
+	// every attempt and were given up on — these are genuine enforcement gaps.
+	progLoadEAGAINExhausted atomic.Uint64
+)
+
+// RecordProgLoadEAGAINRetry records one BPF_PROG_LOAD attempt that was retried
+// after the verifier returned EAGAIN.
+func RecordProgLoadEAGAINRetry() { progLoadEAGAINRetries.Add(1) }
+
+// RecordProgLoadEAGAINExhausted records one BPF_PROG_LOAD call that exhausted
+// all retry attempts on EAGAIN and failed.
+func RecordProgLoadEAGAINExhausted() { progLoadEAGAINExhausted.Add(1) }
+
+// ProgLoadEAGAINRetries returns the cumulative number of BPF_PROG_LOAD attempts
+// retried after the verifier returned EAGAIN.
+func ProgLoadEAGAINRetries() uint64 { return progLoadEAGAINRetries.Load() }
+
+// ProgLoadEAGAINExhausted returns the cumulative number of BPF_PROG_LOAD calls
+// that exhausted all retry attempts on EAGAIN and failed.
+func ProgLoadEAGAINExhausted() uint64 { return progLoadEAGAINExhausted.Load() }
+
+// resetProgLoadEAGAINCounters zeroes the counters. It exists for tests, which
+// rely on a known starting value; counters are otherwise monotonic.
+func resetProgLoadEAGAINCounters() {
+	progLoadEAGAINRetries.Store(0)
+	progLoadEAGAINExhausted.Store(0)
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -47,10 +47,3 @@ func ProgLoadEAGAINRetries() uint64 { return progLoadEAGAINRetries.Load() }
 // ProgLoadEAGAINExhausted returns the cumulative number of BPF_PROG_LOAD calls
 // that exhausted all retry attempts on EAGAIN and failed.
 func ProgLoadEAGAINExhausted() uint64 { return progLoadEAGAINExhausted.Load() }
-
-// resetProgLoadEAGAINCounters zeroes the counters. It exists for tests, which
-// rely on a known starting value; counters are otherwise monotonic.
-func resetProgLoadEAGAINCounters() {
-	progLoadEAGAINRetries.Store(0)
-	progLoadEAGAINExhausted.Store(0)
-}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,60 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProgLoadEAGAINCounters(t *testing.T) {
+	resetProgLoadEAGAINCounters()
+
+	assert.Equal(t, uint64(0), ProgLoadEAGAINRetries())
+	assert.Equal(t, uint64(0), ProgLoadEAGAINExhausted())
+
+	RecordProgLoadEAGAINRetry()
+	RecordProgLoadEAGAINRetry()
+	RecordProgLoadEAGAINExhausted()
+
+	assert.Equal(t, uint64(2), ProgLoadEAGAINRetries())
+	assert.Equal(t, uint64(1), ProgLoadEAGAINExhausted())
+}
+
+func TestProgLoadEAGAINCountersConcurrent(t *testing.T) {
+	resetProgLoadEAGAINCounters()
+
+	const goroutines = 50
+	const perGoroutine = 100
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perGoroutine; j++ {
+				RecordProgLoadEAGAINRetry()
+				RecordProgLoadEAGAINExhausted()
+			}
+		}()
+	}
+	wg.Wait()
+
+	want := uint64(goroutines * perGoroutine)
+	assert.Equal(t, want, ProgLoadEAGAINRetries())
+	assert.Equal(t, want, ProgLoadEAGAINExhausted())
+}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -21,6 +21,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// resetProgLoadEAGAINCounters zeroes the counters so each test starts from a
+// known state; counters are otherwise monotonic.
+func resetProgLoadEAGAINCounters() {
+	progLoadEAGAINRetries.Store(0)
+	progLoadEAGAINExhausted.Store(0)
+}
+
 func TestProgLoadEAGAINCounters(t *testing.T) {
 	resetProgLoadEAGAINCounters()
 

--- a/pkg/progs/loader.go
+++ b/pkg/progs/loader.go
@@ -26,6 +26,7 @@ import (
 	constdef "github.com/aws/aws-ebpf-sdk-go/pkg/constants"
 	"github.com/aws/aws-ebpf-sdk-go/pkg/logger"
 	ebpf_maps "github.com/aws/aws-ebpf-sdk-go/pkg/maps"
+	"github.com/aws/aws-ebpf-sdk-go/pkg/metrics"
 	"github.com/aws/aws-ebpf-sdk-go/pkg/utils"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
@@ -40,6 +41,42 @@ type BpfProgAPIs interface {
 }
 
 var log = logger.Get()
+
+// maxProgLoadAttempts bounds how many times BPF_PROG_LOAD is retried on EAGAIN
+// (verifier interrupted by a pending signal). 5 attempts comfortably covers the
+// observed sub-1% EAGAIN rate while still surfacing a genuinely stuck load.
+const maxProgLoadAttempts = 5
+
+// loadProgWithRetry runs the BPF_PROG_LOAD syscall (provided by load) and
+// retries it on EAGAIN up to maxProgLoadAttempts times.
+//
+// The kernel BPF verifier aborts with EAGAIN if a (non-fatal) signal is pending
+// on the loading thread mid-verify. The Go runtime fires SIGURG constantly for
+// asynchronous preemption and GC stop-the-world, so under high pod-create
+// concurrency a SIGURG can land during a load's verify window and trip an
+// otherwise valid load.
+//
+// The retry is intentionally signal-agnostic rather than masking signals: the
+// culprit (SIGURG) is owned and re-armed by the Go runtime and cannot be
+// cleanly masked without breaking async preemption. It is bounded so a
+// genuinely stuck load still surfaces instead of livelocking.
+func loadProgWithRetry(load func() (uintptr, syscall.Errno)) (uintptr, syscall.Errno) {
+	var fd uintptr
+	var errno syscall.Errno
+	for attempt := 1; ; attempt++ {
+		fd, errno = load()
+		if errno == unix.EAGAIN {
+			if attempt < maxProgLoadAttempts {
+				metrics.RecordProgLoadEAGAINRetry()
+				log.Infof("BPF_PROG_LOAD returned EAGAIN (attempt %d/%d), retrying", attempt, maxProgLoadAttempts)
+				continue
+			}
+			metrics.RecordProgLoadEAGAINExhausted()
+			log.Errorf("BPF_PROG_LOAD still EAGAIN after %d attempts, giving up - prog left unattached", maxProgLoadAttempts)
+		}
+		return fd, errno
+	}
+}
 
 type CreateEBPFProgInput struct {
 	ProgType       string
@@ -231,13 +268,16 @@ func (m *BpfProgram) LoadProg(progMetaData CreateEBPFProgInput) (int, error) {
 	license := []byte(progMetaData.LicenseStr)
 	program.License = uintptr(unsafe.Pointer(&license[0]))
 
-	fd, _, errno := unix.Syscall(unix.SYS_BPF,
-		uintptr(constdef.BPF_PROG_LOAD),
-		uintptr(unsafe.Pointer(&program)),
-		unsafe.Sizeof(program))
-	runtime.KeepAlive(progMetaData.ProgData)
-	runtime.KeepAlive(license)
-	runtime.KeepAlive(logBuf)
+	fd, errno := loadProgWithRetry(func() (uintptr, syscall.Errno) {
+		r, _, e := unix.Syscall(unix.SYS_BPF,
+			uintptr(constdef.BPF_PROG_LOAD),
+			uintptr(unsafe.Pointer(&program)),
+			unsafe.Sizeof(program))
+		runtime.KeepAlive(progMetaData.ProgData)
+		runtime.KeepAlive(license)
+		runtime.KeepAlive(logBuf)
+		return r, e
+	})
 
 	log.Infof("Load prog done with fd : %d errno: %d (%s) insnCnt: %d attrSize: %d progType: %d", int(fd), int(errno), errno.Error(), program.InsnCnt, unsafe.Sizeof(program), program.ProgType)
 	if errno != 0 {

--- a/pkg/progs/loader.go
+++ b/pkg/progs/loader.go
@@ -50,16 +50,9 @@ const maxProgLoadAttempts = 5
 // loadProgWithRetry runs the BPF_PROG_LOAD syscall (provided by load) and
 // retries it on EAGAIN up to maxProgLoadAttempts times.
 //
-// The kernel BPF verifier aborts with EAGAIN if a (non-fatal) signal is pending
-// on the loading thread mid-verify. The Go runtime fires SIGURG constantly for
-// asynchronous preemption and GC stop-the-world, so under high pod-create
-// concurrency a SIGURG can land during a load's verify window and trip an
-// otherwise valid load.
-//
-// The retry is intentionally signal-agnostic rather than masking signals: the
-// culprit (SIGURG) is owned and re-armed by the Go runtime and cannot be
-// cleanly masked without breaking async preemption. It is bounded so a
-// genuinely stuck load still surfaces instead of livelocking.
+// The kernel BPF verifier returns EAGAIN when interrupted by a pending signal
+// mid-verify (see kernel/bpf/verifier.c: bpf_check → signal_pending → -EAGAIN).
+// A bounded retry handles transient interruptions without livelocking.
 func loadProgWithRetry(load func() (uintptr, syscall.Errno)) (uintptr, syscall.Errno) {
 	var fd uintptr
 	var errno syscall.Errno
@@ -72,7 +65,7 @@ func loadProgWithRetry(load func() (uintptr, syscall.Errno)) (uintptr, syscall.E
 				continue
 			}
 			metrics.RecordProgLoadEAGAINExhausted()
-			log.Errorf("BPF_PROG_LOAD still EAGAIN after %d attempts, giving up - prog left unattached", maxProgLoadAttempts)
+			log.Errorf("BPF_PROG_LOAD still EAGAIN after %d attempts, giving up - prog load failed", maxProgLoadAttempts)
 		}
 		return fd, errno
 	}

--- a/pkg/progs/loader_test.go
+++ b/pkg/progs/loader_test.go
@@ -10,15 +10,18 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-//limitations under the License.
+// limitations under the License.
 
 package progs
 
 import (
 	"strings"
+	"syscall"
 	"testing"
 
+	"github.com/aws/aws-ebpf-sdk-go/pkg/metrics"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
 )
 
 // TestVerifierLogString verifies the log is returned up to the first NUL.
@@ -70,4 +73,77 @@ func TestVerifierLogStringDoesNotCopyPadding(t *testing.T) {
 	assert.Equal(t, len(msg), len(got),
 		"returned string must be the prefix only, not the full padded buffer")
 	assert.False(t, strings.ContainsRune(got, 0), "result must not contain NUL bytes")
+}
+
+// fakeLoader returns a load func that yields errnos from the given sequence,
+// one per call, and records how many times it was invoked.
+func fakeLoader(fd uintptr, errnos []syscall.Errno) (func() (uintptr, syscall.Errno), *int) {
+	calls := 0
+	return func() (uintptr, syscall.Errno) {
+		e := errnos[calls]
+		calls++
+		return fd, e
+	}, &calls
+}
+
+func TestLoadProgWithRetry_SuccessFirstTry(t *testing.T) {
+	retriesBefore := metrics.ProgLoadEAGAINRetries()
+	exhaustedBefore := metrics.ProgLoadEAGAINExhausted()
+
+	load, calls := fakeLoader(7, []syscall.Errno{0})
+	fd, errno := loadProgWithRetry(load)
+
+	assert.Equal(t, uintptr(7), fd)
+	assert.Equal(t, syscall.Errno(0), errno)
+	assert.Equal(t, 1, *calls, "should not retry on success")
+	assert.Equal(t, retriesBefore, metrics.ProgLoadEAGAINRetries())
+	assert.Equal(t, exhaustedBefore, metrics.ProgLoadEAGAINExhausted())
+}
+
+func TestLoadProgWithRetry_RecoversAfterEAGAIN(t *testing.T) {
+	retriesBefore := metrics.ProgLoadEAGAINRetries()
+	exhaustedBefore := metrics.ProgLoadEAGAINExhausted()
+
+	// EAGAIN twice, then success on the third attempt.
+	load, calls := fakeLoader(9, []syscall.Errno{unix.EAGAIN, unix.EAGAIN, 0})
+	fd, errno := loadProgWithRetry(load)
+
+	assert.Equal(t, uintptr(9), fd)
+	assert.Equal(t, syscall.Errno(0), errno)
+	assert.Equal(t, 3, *calls)
+	assert.Equal(t, retriesBefore+2, metrics.ProgLoadEAGAINRetries(), "two retries recorded")
+	assert.Equal(t, exhaustedBefore, metrics.ProgLoadEAGAINExhausted(), "no exhaustion on recovery")
+}
+
+func TestLoadProgWithRetry_ExhaustsAllAttempts(t *testing.T) {
+	retriesBefore := metrics.ProgLoadEAGAINRetries()
+	exhaustedBefore := metrics.ProgLoadEAGAINExhausted()
+
+	// EAGAIN on every attempt.
+	errnos := make([]syscall.Errno, maxProgLoadAttempts)
+	for i := range errnos {
+		errnos[i] = unix.EAGAIN
+	}
+	load, calls := fakeLoader(0, errnos)
+	_, errno := loadProgWithRetry(load)
+
+	assert.Equal(t, unix.EAGAIN, errno, "final errno surfaces to caller")
+	assert.Equal(t, maxProgLoadAttempts, *calls, "tries exactly maxProgLoadAttempts times")
+	// maxProgLoadAttempts-1 retries, then 1 exhaustion.
+	assert.Equal(t, retriesBefore+uint64(maxProgLoadAttempts-1), metrics.ProgLoadEAGAINRetries())
+	assert.Equal(t, exhaustedBefore+1, metrics.ProgLoadEAGAINExhausted())
+}
+
+func TestLoadProgWithRetry_NonEAGAINErrorNotRetried(t *testing.T) {
+	retriesBefore := metrics.ProgLoadEAGAINRetries()
+	exhaustedBefore := metrics.ProgLoadEAGAINExhausted()
+
+	// A non-EAGAIN error (e.g. EPERM from the JIT path) must not be retried.
+	load, calls := fakeLoader(0, []syscall.Errno{unix.EPERM})
+	_, errno := loadProgWithRetry(load)
+
+	assert.Equal(t, unix.EPERM, errno)
+	assert.Equal(t, 1, *calls, "non-EAGAIN errors are returned immediately")
+	assert.Equal(t, retriesBefore, metrics.ProgLoadEAGAINRetries())
+	assert.Equal(t, exhaustedBefore, metrics.ProgLoadEAGAINExhausted())
 }


### PR DESCRIPTION
*Issue #, if available:*
Load Prog gets interupted by a syscall pending on the thread which causes the load prog to fail. 

*Description of changes:*
This adds a retry mechanism to retry the load prog on EAGAIN sys error returned during bpf call. It adds a bounded retry mechanism before returning the error back to the caller. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
