### PR TITLE
Add BPF subprogram (.text) support to the ELF loader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ TARGETS := \
 		  $(TESTDATADIR)/tc.subprog_textonly_map \
 		  $(TESTDATADIR)/tc.subprog_nomap \
 		  $(TESTDATADIR)/tc.subprog_globalmap \
+		  $(TESTDATADIR)/tc.subprog_badsection \
 		  $(TESTDATADIR)/tc.multi_subprog \
 		  $(TESTDATADIR)/tc.multi_prog_one_section \
 		  $(TESTDATADIR)/tc.multi_prog_one_section_subprog

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,15 @@ TARGETS := \
 		  $(TESTDATADIR)/recoverydata \
 		  $(TESTDATADIR)/test-kprobe \
 		  $(TESTDATADIR)/xdp \
-		  $(TESTDATADIR)/ring_buffer
+		  $(TESTDATADIR)/ring_buffer \
+		  $(TESTDATADIR)/tc.subprog \
+		  $(TESTDATADIR)/tc.subprog_chain \
+		  $(TESTDATADIR)/tc.subprog_textonly_map \
+		  $(TESTDATADIR)/tc.subprog_nomap \
+		  $(TESTDATADIR)/tc.subprog_globalmap \
+		  $(TESTDATADIR)/tc.multi_subprog \
+		  $(TESTDATADIR)/tc.multi_prog_one_section \
+		  $(TESTDATADIR)/tc.multi_prog_one_section_subprog
 
 %.bpf.elf: %.bpf.c
 	$(CLANG) $(CLANG_INCLUDE) $(BPF_CFLAGS) -c $< -o $@
@@ -63,7 +71,7 @@ $(TESTDATADIR)/vmlinux.h:
 	$(BPFTOOL) btf dump file $(VMLINUX_BTF) format c > $@
 
 ##@ Run Unit Tests
-# Run unit tests
+# Run unit tests (need sudo for few tests, in case sudo doesn't have go in path, then use - sudo env "PATH=$PATH" make unit-test)
 unit-test: $(TESTDATADIR)/vmlinux.h
 unit-test: $(addsuffix .bpf.elf,$(TARGETS))
 unit-test: export AWS_EBPF_SDK_LOG_FILE=$(LOGFILE_PATH)

--- a/pkg/elfparser/elf.go
+++ b/pkg/elfparser/elf.go
@@ -317,7 +317,7 @@ func (e *elfLoader) loadProg(loadedProgData map[string]ebpf_progs.CreateEBPFProg
 		progFD, errno := e.bpfProgApi.LoadProg(pgmInput)
 		if progFD == -1 {
 			log.Infof("Failed to load prog: fd=%d err=%v", progFD, errno)
-			return nil, fmt.Errorf("failed to Load the prog")
+			return nil, fmt.Errorf("failed to Load the prog: %w", errno)
 		}
 		log.Infof("loaded prog with %d", progFD)
 
@@ -633,12 +633,24 @@ func (e *elfLoader) parseAndApplyRelocSection(progIndex uint32, loadedMaps map[s
 			// for independently-verified global functions and they are not
 			// supported here.
 			//
+			// Only .text is appended, so the call target must live there.
+			if int(relocationEntry.symbol.Section) != e.textSectionIndex {
+				return nil, nil, fmt.Errorf("call relocation for %q targets section %d, not .text (%d); calls to subprograms outside .text are not supported",
+					funcName, relocationEntry.symbol.Section, e.textSectionIndex)
+			}
+
 			// Recover A = (insn.imm + 1) * bpfInsDefSize, then rebase onto the
-			// appended .text (which begins progSectionSize bytes into the combined
-			// buffer): target = progSectionSize + S + A.
+			// appended .text: target = progSectionSize + S + A.
 			ebpfInstruction.SrcReg = 1 // BPF_PSEUDO_CALL
 			targetByteOffset := (ebpfInstruction.Imm + 1) * int32(bpfInsDefSize)
 			targetOffset := int32(progSectionSize) + int32(relocationEntry.symbol.Value) + targetByteOffset
+
+			// Guard against a corrupt addend producing an out-of-range target.
+			if targetOffset < 0 || int(targetOffset) >= len(data) {
+				return nil, nil, fmt.Errorf("call relocation for %q computed out-of-bounds target offset %d (combined size %d)",
+					funcName, targetOffset, len(data))
+			}
+
 			targetInsnIdx := targetOffset / int32(bpfInsDefSize)
 			callInsnIdx := int32(relocationEntry.relOffset / bpfInsDefSize)
 			ebpfInstruction.Imm = targetInsnIdx - callInsnIdx - 1
@@ -841,9 +853,9 @@ func (e *elfLoader) parseProg(loadedMaps map[string]ebpf_maps.BpfMap) (map[strin
 							}
 						}
 
-						loadSize := uint64(len(progBody) + len(textPortion))
+						loadSize := len(progBody) + len(textPortion)
 						log.Infof("Program '%s': funcSize=%d sectionLen=%d textLen=%d loadSize=%d insns=%d",
-							ProgName, progSize, dataProg.Size, len(textPortion), loadSize, loadSize/uint64(bpfInsDefSize))
+							ProgName, progSize, dataProg.Size, len(textPortion), loadSize, loadSize/bpfInsDefSize)
 						programData := make([]byte, loadSize)
 						copy(programData, progBody)
 						copy(programData[len(progBody):], textPortion)

--- a/pkg/elfparser/elf.go
+++ b/pkg/elfparser/elf.go
@@ -595,8 +595,8 @@ func (e *elfLoader) parseAndApplyRelocSection(progIndex uint32, loadedMaps map[s
 	log.Infof("Applying Relocations..")
 	associatedMaps := make(map[int]string)
 	for _, relocationEntry := range relocationEntries {
-		if relocationEntry.relOffset >= len(data) {
-			return nil, nil, fmt.Errorf("invalid offset for the relocation entry %d", relocationEntry.relOffset)
+		if relocationEntry.relOffset < 0 || relocationEntry.relOffset+bpfInsDefSize > len(data) {
+			return nil, nil, fmt.Errorf("invalid offset for the relocation entry %d (data len %d)", relocationEntry.relOffset, len(data))
 		}
 
 		//eBPF has one 16-byte instruction: BPF_LD | BPF_DW | BPF_IMM which consists
@@ -645,8 +645,9 @@ func (e *elfLoader) parseAndApplyRelocSection(progIndex uint32, loadedMaps map[s
 			targetByteOffset := (ebpfInstruction.Imm + 1) * int32(bpfInsDefSize)
 			targetOffset := int32(progSectionSize) + int32(relocationEntry.symbol.Value) + targetByteOffset
 
-			// Guard against a corrupt addend producing an out-of-range target.
-			if targetOffset < 0 || int(targetOffset) >= len(data) {
+			// Guard against a corrupt addend producing an out-of-range target;
+			// the full target instruction (bpfInsDefSize bytes) must fit.
+			if targetOffset < 0 || int(targetOffset)+bpfInsDefSize > len(data) {
 				return nil, nil, fmt.Errorf("call relocation for %q computed out-of-bounds target offset %d (combined size %d)",
 					funcName, targetOffset, len(data))
 			}
@@ -704,10 +705,10 @@ func (e *elfLoader) parseAndApplyRelocSection(progIndex uint32, loadedMaps map[s
 
 // countEntryPrograms returns the number of GLOBAL function symbols that live in
 // a program section (i.e. loadable entry programs, not .text subprograms).
-func (e *elfLoader) countEntryPrograms() int {
+func (e *elfLoader) countEntryPrograms() (int, error) {
 	symbolTable, err := e.elfFile.Symbols()
 	if err != nil {
-		return 0
+		return 0, fmt.Errorf("get symbols: %w", err)
 	}
 	count := 0
 	for _, symbol := range symbolTable {
@@ -718,7 +719,7 @@ func (e *elfLoader) countEntryPrograms() int {
 			count++
 		}
 	}
-	return count
+	return count, nil
 }
 
 func (e *elfLoader) parseProg(loadedMaps map[string]ebpf_maps.BpfMap) (map[string]ebpf_progs.CreateEBPFProgInput, error) {
@@ -745,7 +746,11 @@ func (e *elfLoader) parseProg(loadedMaps map[string]ebpf_maps.BpfMap) (map[strin
 		// requires extracting only each program's own call-graph subprograms and
 		// recomputing call offsets/map associations per program. Until then,
 		// fail loud rather than emit bytecode the kernel will reject.
-		if entryProgs := e.countEntryPrograms(); entryProgs > 1 {
+		entryProgs, err := e.countEntryPrograms()
+		if err != nil {
+			return nil, fmt.Errorf("failed to count entry programs: %w", err)
+		}
+		if entryProgs > 1 {
 			log.Errorf("ELF has %d entry programs and uses .text subprograms; this layout is not supported (would produce unreachable subprograms)", entryProgs)
 			return nil, fmt.Errorf("failed to Load the prog: multiple entry programs with .text subprograms is unsupported (appending all .text subprograms to each program creates unreachable instructions the kernel verifier rejects)")
 		}

--- a/pkg/elfparser/elf.go
+++ b/pkg/elfparser/elf.go
@@ -110,6 +110,10 @@ type elfLoader struct {
 
 	reloSectionMap map[uint32]*elf.Section
 	progSectionMap map[uint32]progEntry
+
+	// Support for BPF subprograms (__noinline static functions)
+	textSectionIndex int
+	textSection      *elf.Section
 }
 
 func New(cfg Config) BpfSDKClient {
@@ -146,6 +150,7 @@ func newElfLoader(elfFile *elf.File, bpfmapapi ebpf_maps.BpfMapAPIs, bpfprogapi 
 		customizedPinPath: customizedpinPath,
 		reloSectionMap:    make(map[uint32]*elf.Section),
 		progSectionMap:    make(map[uint32]progEntry),
+		textSectionIndex:  -1,
 	}
 	return elfloader
 }
@@ -307,9 +312,11 @@ func (e *elfLoader) loadProg(loadedProgData map[string]ebpf_progs.CreateEBPFProg
 
 	for _, pgmInput := range loadedProgData {
 		bpfData := BpfData{}
+		log.Infof("Attempting to load prog: type=%s insnCnt=%d dataLen=%d insDefSize=%d",
+			pgmInput.ProgType, len(pgmInput.ProgData)/pgmInput.InsDefSize, len(pgmInput.ProgData), pgmInput.InsDefSize)
 		progFD, errno := e.bpfProgApi.LoadProg(pgmInput)
 		if progFD == -1 {
-			log.Infof("Failed to load prog", "error", errno)
+			log.Infof("Failed to load prog: fd=%d err=%v", progFD, errno)
 			return nil, fmt.Errorf("failed to Load the prog")
 		}
 		log.Infof("loaded prog with %d", progFD)
@@ -378,6 +385,10 @@ func (e *elfLoader) parseSection() error {
 			log.Infof("Found maps Section at Index %v", index)
 			e.mapSection = section
 			e.mapSectionIndex = index
+		} else if section.Type == elf.SHT_PROGBITS && section.Name == ".text" {
+			log.Infof("Found .text section (BPF subprograms) at index %d", index)
+			e.textSection = section
+			e.textSectionIndex = index
 		} else if section.Type == elf.SHT_PROGBITS {
 			log.Infof("Found PROG Section at Index %v and Name %s", index, section.Name)
 			splitProgType := strings.Split(section.Name, "/")
@@ -479,16 +490,102 @@ func (e *elfLoader) parseMap(customData BpfCustomData) ([]ebpf_maps.CreateEBPFMa
 	return parsedMapData, nil
 }
 
-func (e *elfLoader) parseAndApplyRelocSection(progIndex uint32, loadedMaps map[string]ebpf_maps.BpfMap) ([]byte, map[int]string, error) {
+func (e *elfLoader) getRelocatedTextSection(loadedMaps map[string]ebpf_maps.BpfMap) ([]byte, map[int]string, error) {
+	if e.textSection == nil {
+		return nil, nil, nil
+	}
+
+	data, err := e.textSection.Data()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read .text section: %v", err)
+	}
+	log.Infof("Read .text section: %d bytes (%d insns)", len(data), len(data)/bpfInsDefSize)
+
+	// Maps referenced only from within .text subprograms must still be reported
+	// as associated with the owning program, otherwise the prog->map name table
+	// (built from the main program section relocations) misses them and callers
+	// that look maps up by name (e.g. TC_EGRESS_MAP) get an empty entry.
+	textAssociatedMaps := make(map[int]string)
+
+	// Apply map relocations from .rel.text
+	reloSection := e.reloSectionMap[uint32(e.textSectionIndex)]
+	if reloSection == nil {
+		log.Infof("No .rel.text relocation section found")
+		return data, textAssociatedMaps, nil
+	}
+
+	relocationEntries, err := e.parseRelocationSection(reloSection, e.elfFile)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse .rel.text: %v", err)
+	}
+
+	for _, relEntry := range relocationEntries {
+		if relEntry.relOffset < 0 || relEntry.relOffset+bpfInsDefSize > len(data) {
+			return nil, nil, fmt.Errorf("invalid .text relocation offset %d (data len %d)", relEntry.relOffset, len(data))
+		}
+
+		insnCode := data[relEntry.relOffset]
+
+		// Skip BPF_CALL relocations within .text (internal function calls)
+		if insnCode == (unix.BPF_JMP | unix.BPF_CALL) {
+			log.Infof(".text: skipping BPF_CALL relocation for %s at offset %d", relEntry.symbol.Name, relEntry.relOffset)
+			continue
+		}
+
+		// Must be a map relocation
+		if insnCode != (unix.BPF_LD | unix.BPF_IMM | unix.BPF_DW) {
+			return nil, nil, fmt.Errorf("invalid .text BPF instruction at %d: 0x%x", relEntry.relOffset, insnCode)
+		}
+
+		mapName := relEntry.symbol.Name
+		var mapFD int
+		if progMap, ok := loadedMaps[mapName]; ok {
+			mapFD = int(progMap.MapFD)
+			// Record the local map so it is reported as associated with the prog.
+			textAssociatedMaps[int(progMap.MapID)] = mapName
+		} else if globalMapFd, ok := sdkCache.Get(mapName); ok {
+			mapFD = globalMapFd
+		} else {
+			return nil, nil, fmt.Errorf("map '%s' not found for .text relocation", mapName)
+		}
+
+		log.Infof(".text: applying map relocation for %s (FD=%d) at offset %d", mapName, mapFD, relEntry.relOffset)
+		ebpfInsn := &utils.BPFInsn{
+			Code:   data[relEntry.relOffset],
+			DstReg: data[relEntry.relOffset+1] & 0xf,
+			SrcReg: 1,
+			Off:    int16(binary.LittleEndian.Uint16(data[relEntry.relOffset+2:])),
+			Imm:    int32(mapFD),
+		}
+		copy(data[relEntry.relOffset:relEntry.relOffset+8], ebpfInsn.ConvertBPFInstructionToByteStream())
+	}
+
+	return data, textAssociatedMaps, nil
+}
+
+func (e *elfLoader) parseAndApplyRelocSection(progIndex uint32, loadedMaps map[string]ebpf_maps.BpfMap, textData []byte) ([]byte, map[int]string, error) {
 	progEntry := e.progSectionMap[progIndex]
 	reloSection := e.reloSectionMap[progIndex]
 
-	data, err := progEntry.progSection.Data()
+	progData, err := progEntry.progSection.Data()
 	if err != nil {
 		return nil, nil, err
 	}
+	progSectionSize := len(progData)
 	log.Infof("Loading Program with relocation section; Info:%v; Name: %s, Type: %s; Size: %v", reloSection.Info,
 		reloSection.Name, reloSection.Type, reloSection.Size)
+
+	// Append .text section (subprograms) after program section data
+	var data []byte
+	if len(textData) > 0 {
+		data = make([]byte, len(progData)+len(textData))
+		copy(data, progData)
+		copy(data[len(progData):], textData)
+		log.Infof("Appended .text section: progSize=%d textSize=%d totalSize=%d",
+			progSectionSize, len(textData), len(data))
+	} else {
+		data = progData
+	}
 
 	relocationEntries, err := e.parseRelocationSection(reloSection, e.elfFile)
 	if err != nil || len(relocationEntries) == 0 {
@@ -515,6 +612,42 @@ func (e *elfLoader) parseAndApplyRelocSection(progIndex uint32, loadedMaps map[s
 
 		log.Infof("BPF Instruction code: %s; offset: %d; imm: %d", ebpfInstruction.Code, ebpfInstruction.Off, ebpfInstruction.Imm)
 
+		// Handle BPF-to-BPF function call relocations (for __noinline subprograms)
+		if ebpfInstruction.Code == (unix.BPF_JMP | unix.BPF_CALL) { // BPF_JMP | BPF_CALL
+			funcName := relocationEntry.symbol.Name
+			// R_BPF_64_32 relocation for a call insn: clang encodes the callee
+			// target into insn.imm as (S + A) / 8 - 1, where S = the symbol's
+			// value and A = the addend.
+			// Ref: kernel Documentation/bpf/llvm_reloc.rst (R_BPF_64_32, call insn).
+			//
+			// This SDK only handles STATIC (__noinline) subprograms: clang
+			// relocates those against the .text SECTION symbol, so S = 0 and the
+			// callee's byte offset within .text is carried entirely in A. The
+			// +symbol.Value term below is the general R_BPF_64_32 reconstruction
+			// and is 0 in this (only supported) case.
+			//
+			// Global (non-static) BPF functions are also called via
+			// BPF_PSEUDO_CALL, but the verifier checks them independently against
+			// their BTF-described argument types instead of inlining caller
+			// state. This concatenate-.text + PC-relative rewrite is not built
+			// for independently-verified global functions and they are not
+			// supported here.
+			//
+			// Recover A = (insn.imm + 1) * bpfInsDefSize, then rebase onto the
+			// appended .text (which begins progSectionSize bytes into the combined
+			// buffer): target = progSectionSize + S + A.
+			ebpfInstruction.SrcReg = 1 // BPF_PSEUDO_CALL
+			targetByteOffset := (ebpfInstruction.Imm + 1) * int32(bpfInsDefSize)
+			targetOffset := int32(progSectionSize) + int32(relocationEntry.symbol.Value) + targetByteOffset
+			targetInsnIdx := targetOffset / int32(bpfInsDefSize)
+			callInsnIdx := int32(relocationEntry.relOffset / bpfInsDefSize)
+			ebpfInstruction.Imm = targetInsnIdx - callInsnIdx - 1
+			log.Infof("Function call relocation: %s -> targetInsn=%d callInsn=%d relImm=%d progSecSize=%d symVal=%d addend=%d",
+				funcName, targetInsnIdx, callInsnIdx, ebpfInstruction.Imm, progSectionSize, relocationEntry.symbol.Value, targetByteOffset)
+			copy(data[relocationEntry.relOffset:relocationEntry.relOffset+8], ebpfInstruction.ConvertBPFInstructionToByteStream())
+			continue
+		}
+
 		//Validate for Invalid BPF instructions
 		if ebpfInstruction.Code != (unix.BPF_LD | unix.BPF_IMM | unix.BPF_DW) {
 			return nil, nil, fmt.Errorf("invalid BPF instruction (at %d): %d",
@@ -523,8 +656,6 @@ func (e *elfLoader) parseAndApplyRelocSection(progIndex uint32, loadedMaps map[s
 
 		// Point BPF instruction to the FD of the map referenced. Update the last 4 bytes of
 		// instruction (immediate constant) with the map's FD.
-		// BPF_MEM | <size> | BPF_STX:  *(size *) (dst_reg + off) = src_reg
-		// BPF_MEM | <size> | BPF_ST:   *(size *) (dst_reg + off) = imm32
 		mapName := relocationEntry.symbol.Name
 		log.Infof("Map to be relocated; Name: %s", mapName)
 		var mapFD int
@@ -559,9 +690,54 @@ func (e *elfLoader) parseAndApplyRelocSection(progIndex uint32, loadedMaps map[s
 
 }
 
+// countEntryPrograms returns the number of GLOBAL function symbols that live in
+// a program section (i.e. loadable entry programs, not .text subprograms).
+func (e *elfLoader) countEntryPrograms() int {
+	symbolTable, err := e.elfFile.Symbols()
+	if err != nil {
+		return 0
+	}
+	count := 0
+	for _, symbol := range symbolTable {
+		if elf.ST_TYPE(symbol.Info) != elf.STT_FUNC || elf.ST_BIND(symbol.Info) != elf.STB_GLOBAL {
+			continue
+		}
+		if _, ok := e.progSectionMap[uint32(symbol.Section)]; ok {
+			count++
+		}
+	}
+	return count
+}
+
 func (e *elfLoader) parseProg(loadedMaps map[string]ebpf_maps.BpfMap) (map[string]ebpf_progs.CreateEBPFProgInput, error) {
 	//Get prog data
 	var pgmList = make(map[string]ebpf_progs.CreateEBPFProgInput)
+
+	// Pre-process .text section (BPF subprograms) with map relocations applied.
+	// textMaps holds maps referenced only from within subprograms; they must be
+	// merged into every prog that pulls in .text so the prog->map association is
+	// complete (callers look maps up by name).
+	textData, textMaps, err := e.getRelocatedTextSection(loadedMaps)
+	if err != nil {
+		return nil, fmt.Errorf("failed to process .text section: %v", err)
+	}
+	if len(textData) > 0 {
+		log.Infof("Prepared .text section: %d bytes (%d insns)", len(textData), len(textData)/bpfInsDefSize)
+
+		// KNOWN LIMITATION: the loader appends the entire combined .text
+		// section (every subprogram in the ELF) to each program. That is only
+		// correct when a single entry program consumes those subprograms. When
+		// an ELF has more than one entry program AND uses .text subprograms,
+		// every program ends up carrying subprograms it never calls; the kernel
+		// verifier then rejects the load with "unreachable insn". Proper support
+		// requires extracting only each program's own call-graph subprograms and
+		// recomputing call offsets/map associations per program. Until then,
+		// fail loud rather than emit bytecode the kernel will reject.
+		if entryProgs := e.countEntryPrograms(); entryProgs > 1 {
+			log.Errorf("ELF has %d entry programs and uses .text subprograms; this layout is not supported (would produce unreachable subprograms)", entryProgs)
+			return nil, fmt.Errorf("failed to Load the prog: multiple entry programs with .text subprograms is unsupported (appending all .text subprograms to each program creates unreachable instructions the kernel verifier rejects)")
+		}
+	}
 
 	for progIndex, progEntry := range e.progSectionMap {
 		dataProg := progEntry.progSection
@@ -580,13 +756,23 @@ func (e *elfLoader) parseProg(loadedMaps map[string]ebpf_maps.BpfMap) (map[strin
 		if e.reloSectionMap[progIndex] == nil {
 			log.Infof("Relocation is not needed")
 		} else {
-			progData, associatedMaps, err := e.parseAndApplyRelocSection(progIndex, loadedMaps)
+			progData, associatedMaps, err := e.parseAndApplyRelocSection(progIndex, loadedMaps, textData)
 			if err != nil {
 				return nil, fmt.Errorf("failed to apply relocation: %v", err)
 			}
 			//Replace data with relocated data
 			data = progData
 			linkedMaps = associatedMaps
+			// Merge in maps referenced only from .text subprograms so the
+			// program's associated-map name table is complete.
+			if len(textData) > 0 {
+				for mapID, mapName := range textMaps {
+					if _, exists := linkedMaps[mapID]; !exists {
+						linkedMaps[mapID] = mapName
+						log.Infof("Adding .text-referenced map %s (ID %d) to prog associated maps", mapName, mapID)
+					}
+				}
+			}
 		}
 
 		symbolTable, err := e.elfFile.Symbols()
@@ -616,9 +802,51 @@ func (e *elfLoader) parseProg(loadedMaps map[string]ebpf_maps.BpfMap) (map[strin
 					if symbol.Value >= dataProg.Addr && symbol.Value < dataProg.Addr+dataProg.Size {
 
 						dataStart := (symbol.Value - dataProg.Addr)
-						dataEnd := dataStart + progSize
-						programData := make([]byte, progSize)
-						copy(programData, data[dataStart:dataEnd])
+
+						// Bounds-check against the actual relocated buffer using
+						// subtraction form to avoid uint64 overflow. dataProg.Size
+						// is the original section length; `data` may be longer
+						// because .text subprograms were appended after it.
+						dataLen := uint64(len(data))
+						if dataStart > dataLen || progSize > dataLen-dataStart || dataProg.Size > dataLen {
+							log.Infof("Program '%s' out of bounds: dataStart=%d progSize=%d dataLen=%d sectionLen=%d", ProgName, dataStart, progSize, dataLen, dataProg.Size)
+							return nil, fmt.Errorf("failed to Load the prog")
+						}
+
+						// Slice exactly this program's own bytes (by its symbol
+						// size). Using the section end here would make the first
+						// of several programs that share a section swallow the
+						// bytes of the programs that follow it.
+						progBody := data[dataStart : dataStart+progSize]
+
+						// .text subprograms (if any) were appended to `data`
+						// after the original program section. Carry them along
+						// so BPF-to-BPF calls resolve.
+						var textPortion []byte
+						if dataLen > dataProg.Size {
+							textPortion = data[dataProg.Size:]
+
+							// BPF-to-BPF call offsets are computed (in
+							// parseAndApplyRelocSection) relative to the start of
+							// the whole program section. That only matches the
+							// trimmed layout we build here (this program's body +
+							// .text) when the program occupies the entire section.
+							// If the program shares its section with other
+							// programs AND the section uses .text subprograms, the
+							// call offsets would be wrong. Fail loud rather than
+							// load corrupt bytecode.
+							if dataStart != 0 || progSize != dataProg.Size {
+								log.Errorf("Program '%s' shares a section with other programs and that section uses .text subprograms; BPF-to-BPF call relocation is not supported for this layout", ProgName)
+								return nil, fmt.Errorf("failed to Load the prog: unsupported shared-section + .text layout for program '%s'", ProgName)
+							}
+						}
+
+						loadSize := uint64(len(progBody) + len(textPortion))
+						log.Infof("Program '%s': funcSize=%d sectionLen=%d textLen=%d loadSize=%d insns=%d",
+							ProgName, progSize, dataProg.Size, len(textPortion), loadSize, loadSize/uint64(bpfInsDefSize))
+						programData := make([]byte, loadSize)
+						copy(programData, progBody)
+						copy(programData[len(progBody):], textPortion)
 
 						pinLocation := ProgName
 						if len(e.customizedPinPath) != 0 {

--- a/pkg/elfparser/elf_test.go
+++ b/pkg/elfparser/elf_test.go
@@ -858,6 +858,31 @@ func TestLoadMap(t *testing.T) {
 	}
 }
 
+func TestLoadProgReturnsUnderlyingError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	loadErr := errors.New("verifier rejected program")
+	mockBpfProgAPI := mock_ebpf_progs.NewMockBpfProgAPIs(ctrl)
+	mockBpfProgAPI.EXPECT().LoadProg(gomock.Any()).Return(-1, loadErr)
+
+	elfLoader := &elfLoader{
+		bpfProgApi: mockBpfProgAPI,
+	}
+	loadedProgData := map[string]ebpf_progs.CreateEBPFProgInput{
+		"/sys/fs/bpf/globals/aws/programs/test_prog": {
+			ProgType:   "tc_cls",
+			ProgData:   make([]byte, bpfInsDefSize),
+			PinPath:    "/sys/fs/bpf/globals/aws/programs/test_prog",
+			InsDefSize: bpfInsDefSize,
+		},
+	}
+
+	_, err := elfLoader.loadProg(loadedProgData, nil)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, loadErr)
+}
+
 func TestSubprogramParseProg(t *testing.T) {
 	m := setup(t, "../../test-data/tc.subprog.bpf.elf")
 	defer m.ctrl.Finish()
@@ -1465,4 +1490,33 @@ func TestSubprogramRealKernelLoad(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestSubprogramInCustomSectionRejected verifies a call to a subprogram outside
+// .text (custom-section __noinline) is rejected rather than mis-relocated.
+func TestSubprogramInCustomSectionRejected(t *testing.T) {
+	m := setup(t, "../../test-data/tc.subprog_badsection.bpf.elf")
+	defer m.ctrl.Finish()
+	f, err := os.Open(m.path)
+	if !assert.NoError(t, err, "open test ELF") {
+		return
+	}
+	defer f.Close()
+
+	elfFile, err := elf.NewFile(f)
+	assert.NoError(t, err)
+	elfLoader := newElfLoader(elfFile, m.ebpf_maps, m.ebpf_progs, "test", nil)
+	assert.NoError(t, elfLoader.parseSection())
+
+	mapData, err := elfLoader.parseMap(BpfCustomData{})
+	assert.NoError(t, err)
+	m.ebpf_maps.EXPECT().CreateBPFMap(gomock.Any()).Return(ebpf_maps.BpfMap{MapFD: 5}, nil).AnyTimes()
+	m.ebpf_maps.EXPECT().GetBPFmapInfo(gomock.Any()).Return(ebpf_maps.BpfMapInfo{Id: 100}, nil).AnyTimes()
+	m.ebpf_maps.EXPECT().PinMap(gomock.Any(), gomock.Any()).AnyTimes()
+	m.ebpf_maps.EXPECT().GetMapFromPinPath(gomock.Any()).AnyTimes()
+	loadedMaps, err := elfLoader.loadMap(mapData)
+	assert.NoError(t, err)
+
+	_, err = elfLoader.parseProg(loadedMaps)
+	assert.Error(t, err, "call to a subprogram outside .text must be rejected")
 }

--- a/pkg/elfparser/elf_test.go
+++ b/pkg/elfparser/elf_test.go
@@ -16,6 +16,7 @@ package elfparser
 
 import (
 	"debug/elf"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"os"
@@ -24,6 +25,7 @@ import (
 	"testing"
 
 	ebpf_maps "github.com/aws/aws-ebpf-sdk-go/pkg/maps"
+	ebpf_progs "github.com/aws/aws-ebpf-sdk-go/pkg/progs"
 
 	constdef "github.com/aws/aws-ebpf-sdk-go/pkg/constants"
 	mock_ebpf_maps "github.com/aws/aws-ebpf-sdk-go/pkg/maps/mocks"
@@ -31,6 +33,7 @@ import (
 	"github.com/aws/aws-ebpf-sdk-go/pkg/utils"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
 )
 
 var testNamespacedMaps = []string{
@@ -88,6 +91,18 @@ func TestLoad(t *testing.T) {
 			elfFileName: "../../test-data/test.map.bpf.elf",
 			wantMap:     1,
 			wantProg:    0,
+		},
+		{
+			name:        "Test Load ELF with subprograms",
+			elfFileName: "../../test-data/tc.subprog.bpf.elf",
+			wantMap:     1,
+			wantProg:    1,
+		},
+		{
+			name:        "Test Load ELF with chained subprograms",
+			elfFileName: "../../test-data/tc.subprog_chain.bpf.elf",
+			wantMap:     1,
+			wantProg:    1,
 		},
 	}
 
@@ -198,6 +213,54 @@ func TestParseSection(t *testing.T) {
 			} else {
 				gotMapIndex := elfLoader.mapSectionIndex
 				assert.Equal(t, tt.want, gotMapIndex)
+			}
+		})
+	}
+
+	texttests := []struct {
+		name            string
+		elfFileName     string
+		wantTextSection bool
+		wantTextRelo    bool
+	}{
+		{
+			name:            "Empty .text section in regular ELF",
+			elfFileName:     "../../test-data/tc.ingress.bpf.elf",
+			wantTextSection: true,  // clang always emits a .text section
+			wantTextRelo:    false, // but no .rel.text for regular ELFs
+		},
+		{
+			name:            "Has .text section with subprograms",
+			elfFileName:     "../../test-data/tc.subprog.bpf.elf",
+			wantTextSection: true,
+			wantTextRelo:    true, // has .rel.text for map relocation in subprogram
+		},
+	}
+
+	for _, tt := range texttests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := setup(t, tt.elfFileName)
+			defer m.ctrl.Finish()
+			f, _ := os.Open(m.path)
+			defer f.Close()
+
+			elfFile, err := elf.NewFile(f)
+			assert.NoError(t, err)
+			elfLoader := newElfLoader(elfFile, m.ebpf_maps, m.ebpf_progs, "test", nil)
+
+			err = elfLoader.parseSection()
+			assert.NoError(t, err)
+
+			if tt.wantTextSection {
+				assert.NotNil(t, elfLoader.textSection)
+				assert.NotEqual(t, -1, elfLoader.textSectionIndex)
+			} else {
+				assert.Nil(t, elfLoader.textSection)
+				assert.Equal(t, -1, elfLoader.textSectionIndex)
+			}
+
+			if tt.wantTextRelo {
+				assert.NotNil(t, elfLoader.reloSectionMap[uint32(elfLoader.textSectionIndex)])
 			}
 		})
 	}
@@ -433,6 +496,12 @@ func TestParseProg(t *testing.T) {
 			name:        "Test prog data",
 			elfFileName: "../../test-data/tc.ingress.bpf.elf",
 			want:        3,
+			wantErr:     nil,
+		},
+		{
+			name:        "Test prog data with subprograms",
+			elfFileName: "../../test-data/tc.subprog.bpf.elf",
+			want:        1,
 			wantErr:     nil,
 		},
 		{
@@ -784,6 +853,615 @@ func TestLoadMap(t *testing.T) {
 				} else {
 					t.Errorf("Expected map 'test_map' to be loaded")
 				}
+			}
+		})
+	}
+}
+
+func TestSubprogramParseProg(t *testing.T) {
+	m := setup(t, "../../test-data/tc.subprog.bpf.elf")
+	defer m.ctrl.Finish()
+	f, _ := os.Open(m.path)
+	defer f.Close()
+
+	elfFile, err := elf.NewFile(f)
+	assert.NoError(t, err)
+	elfLoader := newElfLoader(elfFile, m.ebpf_maps, m.ebpf_progs, "test", nil)
+
+	err = elfLoader.parseSection()
+	assert.NoError(t, err)
+
+	assert.NotNil(t, elfLoader.textSection)
+	assert.NotEqual(t, -1, elfLoader.textSectionIndex)
+	assert.NotNil(t, elfLoader.reloSectionMap[uint32(elfLoader.textSectionIndex)])
+
+	mapData, err := elfLoader.parseMap(BpfCustomData{})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(mapData))
+
+	m.ebpf_maps.EXPECT().CreateBPFMap(gomock.Any()).Return(ebpf_maps.BpfMap{MapFD: 5}, nil).AnyTimes()
+	m.ebpf_maps.EXPECT().GetBPFmapInfo(gomock.Any()).Return(ebpf_maps.BpfMapInfo{Id: 100}, nil).AnyTimes()
+	m.ebpf_maps.EXPECT().PinMap(gomock.Any(), gomock.Any()).AnyTimes()
+	m.ebpf_maps.EXPECT().GetMapFromPinPath(gomock.Any()).AnyTimes()
+
+	loadedMaps, err := elfLoader.loadMap(mapData)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(loadedMaps))
+
+	parsedProgData, err := elfLoader.parseProg(loadedMaps)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(parsedProgData))
+
+	textData, err := elfLoader.textSection.Data()
+	assert.NoError(t, err)
+	textSize := len(textData)
+	assert.Greater(t, textSize, 0, ".text section should have data")
+
+	// ProgData must be the tc_cls section with .text subprograms appended.
+	for _, progInput := range parsedProgData {
+		assert.Equal(t, "tc_cls", progInput.ProgType)
+
+		var tcProgSize int
+		for idx, entry := range elfLoader.progSectionMap {
+			if entry.progType == "tc_cls" {
+				sec := elfLoader.progSectionMap[idx]
+				secData, _ := sec.progSection.Data()
+				tcProgSize = len(secData)
+				break
+			}
+		}
+		assert.Greater(t, len(progInput.ProgData), tcProgSize,
+			"Program data should include appended .text subprogram data")
+		assert.Equal(t, tcProgSize+textSize, len(progInput.ProgData),
+			"Program data should be tc_cls section + .text section")
+	}
+}
+
+// TestChainedSubprogramParseProg tests BPF programs with chained subprogram calls:
+// handle_ingress (tc_cls) -> lookup_conntrack (.text) -> do_lookup (.text)
+// This verifies that .text-internal calls (resolved by clang at compile time)
+// remain valid after .text is appended to the program section.
+func TestChainedSubprogramParseProg(t *testing.T) {
+	m := setup(t, "../../test-data/tc.subprog_chain.bpf.elf")
+	defer m.ctrl.Finish()
+	f, _ := os.Open(m.path)
+	defer f.Close()
+
+	elfFile, err := elf.NewFile(f)
+	assert.NoError(t, err)
+	elfLoader := newElfLoader(elfFile, m.ebpf_maps, m.ebpf_progs, "test", nil)
+
+	err = elfLoader.parseSection()
+	assert.NoError(t, err)
+
+	assert.NotNil(t, elfLoader.textSection)
+	assert.NotEqual(t, -1, elfLoader.textSectionIndex)
+	assert.NotNil(t, elfLoader.reloSectionMap[uint32(elfLoader.textSectionIndex)])
+
+	textData, err := elfLoader.textSection.Data()
+	assert.NoError(t, err)
+	textInsns := len(textData) / bpfInsDefSize
+	assert.Greater(t, textInsns, 2, ".text should contain multiple subprograms")
+
+	symbols, err := elfFile.Symbols()
+	assert.NoError(t, err)
+	textFuncs := map[string]elf.Symbol{}
+	for _, sym := range symbols {
+		if int(sym.Section) == elfLoader.textSectionIndex && elf.ST_TYPE(sym.Info) == elf.STT_FUNC {
+			textFuncs[sym.Name] = sym
+		}
+	}
+	assert.Contains(t, textFuncs, "lookup_conntrack")
+	assert.Contains(t, textFuncs, "do_lookup")
+
+	mapData, err := elfLoader.parseMap(BpfCustomData{})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(mapData))
+
+	m.ebpf_maps.EXPECT().CreateBPFMap(gomock.Any()).Return(ebpf_maps.BpfMap{MapFD: 5}, nil).AnyTimes()
+	m.ebpf_maps.EXPECT().GetBPFmapInfo(gomock.Any()).Return(ebpf_maps.BpfMapInfo{Id: 100}, nil).AnyTimes()
+	m.ebpf_maps.EXPECT().PinMap(gomock.Any(), gomock.Any()).AnyTimes()
+	m.ebpf_maps.EXPECT().GetMapFromPinPath(gomock.Any()).AnyTimes()
+
+	loadedMaps, err := elfLoader.loadMap(mapData)
+	assert.NoError(t, err)
+
+	parsedProgData, err := elfLoader.parseProg(loadedMaps)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(parsedProgData))
+
+	// Exactly one entry program (handle_ingress); pull it out of the map.
+	var progInput ebpf_progs.CreateEBPFProgInput
+	for _, p := range parsedProgData {
+		progInput = p
+	}
+	assert.Equal(t, "tc_cls", progInput.ProgType)
+
+	var tcProgSize int
+	for idx, entry := range elfLoader.progSectionMap {
+		if entry.progType == "tc_cls" {
+			secData, _ := elfLoader.progSectionMap[idx].progSection.Data()
+			tcProgSize = len(secData)
+			break
+		}
+	}
+	textSize := len(textData)
+
+	assert.Equal(t, tcProgSize+textSize, len(progInput.ProgData),
+		"Program data should be tc_cls section + .text section")
+
+	// Verify the BPF_CALL from tc_cls to lookup_conntrack has correct relocation.
+	// Scan for the BPF_CALL instruction in the tc_cls section rather than
+	// assuming a fixed offset, since clang may reorder instructions.
+	callInsnOffset := -1
+	for off := 0; off < tcProgSize; off += bpfInsDefSize {
+		if progInput.ProgData[off] == (unix.BPF_JMP|unix.BPF_CALL) && progInput.ProgData[off+1]>>4 == 1 {
+			callInsnOffset = off
+			break
+		}
+	}
+	assert.NotEqual(t, -1, callInsnOffset, "tc_cls should contain a BPF_PSEUDO_CALL instruction")
+
+	tcInsnCount := tcProgSize / bpfInsDefSize
+	lookupOffset := textFuncs["lookup_conntrack"].Value
+	expectedTargetInsn := tcInsnCount + int(lookupOffset)/bpfInsDefSize
+	expectedImm := int32(expectedTargetInsn - callInsnOffset/bpfInsDefSize - 1)
+	actualImm := int32(binary.LittleEndian.Uint32(progInput.ProgData[callInsnOffset+4 : callInsnOffset+8]))
+	assert.Equal(t, expectedImm, actualImm,
+		"BPF_CALL Imm should point to lookup_conntrack in appended .text")
+
+	// Verify .text-internal call: lookup_conntrack -> do_lookup
+	// Scan for the BPF_PSEUDO_CALL within lookup_conntrack's range in the combined data.
+	lookupStart := tcProgSize + int(lookupOffset)
+	lookupEnd := tcProgSize + textSize
+	chainCallOffset := -1
+	for off := lookupStart; off < lookupEnd; off += bpfInsDefSize {
+		if progInput.ProgData[off] == (unix.BPF_JMP|unix.BPF_CALL) && progInput.ProgData[off+1]>>4 == 1 {
+			chainCallOffset = off
+			break
+		}
+	}
+	assert.NotEqual(t, -1, chainCallOffset, "lookup_conntrack should contain a BPF_PSEUDO_CALL to do_lookup")
+
+	// The Imm for the .text-internal call should be the relative offset to do_lookup
+	doLookupOffset := textFuncs["do_lookup"].Value
+	chainCallInsnIdx := (chainCallOffset - tcProgSize) / bpfInsDefSize
+	doLookupInsnIdx := int(doLookupOffset) / bpfInsDefSize
+	expectedChainImm := int32(doLookupInsnIdx - chainCallInsnIdx - 1)
+	actualChainImm := int32(binary.LittleEndian.Uint32(progInput.ProgData[chainCallOffset+4 : chainCallOffset+8]))
+	assert.Equal(t, expectedChainImm, actualChainImm,
+		"Chained BPF_CALL Imm should point from lookup_conntrack to do_lookup within .text")
+
+	// Verify the map FD relocation was applied INSIDE the appended .text.
+	// lookup_conntrack does a bpf_map_lookup_elem on aws_conntrack_map, which
+	// compiles to a BPF_LD_IMM_DW (0x18) whose 64-bit immediate must be
+	// patched with the map FD (5, from the CreateBPFMap mock above). Find
+	// that instruction within the .text region of the combined program data
+	// and assert the FD landed in its immediate.
+	const bpfLdImmDW = byte(unix.BPF_LD | unix.BPF_IMM | unix.BPF_DW)
+	mapLoadOffset := -1
+	for off := tcProgSize; off+16 <= len(progInput.ProgData); off += bpfInsDefSize {
+		if progInput.ProgData[off] == bpfLdImmDW {
+			mapLoadOffset = off
+			break
+		}
+	}
+	assert.NotEqual(t, -1, mapLoadOffset, ".text should contain a BPF_LD_IMM_DW map load")
+	mapFD := int32(binary.LittleEndian.Uint32(progInput.ProgData[mapLoadOffset+4 : mapLoadOffset+8]))
+	assert.Equal(t, int32(5), mapFD,
+		"map FD should be patched into the BPF_LD_IMM_DW immediate inside .text")
+}
+
+// TestMultiProgramOneSectionParseProg guards against a regression where two
+// GLOBAL programs share a single ELF section. Each program is its own
+// STT_FUNC symbol with a distinct offset and size within the section; the
+// loader must slice each program by its own symbol size. Loading from a
+// program's start to the end of the whole section would make the first
+// program swallow the bytes of the second.
+func TestMultiProgramOneSectionParseProg(t *testing.T) {
+	m := setup(t, "../../test-data/tc.multi_prog_one_section.bpf.elf")
+	defer m.ctrl.Finish()
+	f, err := os.Open(m.path)
+	if !assert.NoError(t, err, "open test ELF") {
+		return
+	}
+	defer f.Close()
+
+	elfFile, err := elf.NewFile(f)
+	assert.NoError(t, err)
+	elfLoader := newElfLoader(elfFile, m.ebpf_maps, m.ebpf_progs, "test", nil)
+
+	err = elfLoader.parseSection()
+	assert.NoError(t, err)
+
+	// Both programs live in the same section, so there is exactly one prog
+	// section entry.
+	assert.Equal(t, 1, len(elfLoader.progSectionMap))
+
+	mapData, err := elfLoader.parseMap(BpfCustomData{})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(mapData))
+
+	m.ebpf_maps.EXPECT().CreateBPFMap(gomock.Any()).Return(ebpf_maps.BpfMap{MapFD: 7}, nil).AnyTimes()
+	m.ebpf_maps.EXPECT().GetBPFmapInfo(gomock.Any()).Return(ebpf_maps.BpfMapInfo{Id: 100}, nil).AnyTimes()
+	m.ebpf_maps.EXPECT().PinMap(gomock.Any(), gomock.Any()).AnyTimes()
+	m.ebpf_maps.EXPECT().GetMapFromPinPath(gomock.Any()).AnyTimes()
+
+	loadedMaps, err := elfLoader.loadMap(mapData)
+	assert.NoError(t, err)
+
+	// Gather the two GLOBAL program symbols and their individual sizes.
+	symbols, err := elfFile.Symbols()
+	assert.NoError(t, err)
+	progSyms := map[string]elf.Symbol{}
+	for _, sym := range symbols {
+		if elf.ST_TYPE(sym.Info) == elf.STT_FUNC && elf.ST_BIND(sym.Info) == elf.STB_GLOBAL {
+			if int(sym.Section) == int(elfLoader.textSectionIndex) {
+				continue
+			}
+			progSyms[sym.Name] = sym
+		}
+	}
+	assert.Contains(t, progSyms, "prog_first")
+	assert.Contains(t, progSyms, "prog_second")
+
+	parsedProgData, err := elfLoader.parseProg(loadedMaps)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(parsedProgData))
+
+	// Each program's bytecode must be exactly its own symbol size -- not the
+	// whole section, and not bleeding into the other program.
+	byName := map[string]ebpf_progs.CreateEBPFProgInput{}
+	for _, p := range parsedProgData {
+		// Pin path is suffixed with the program (symbol) name.
+		for name := range progSyms {
+			if strings.HasSuffix(p.PinPath, name) {
+				byName[name] = p
+			}
+		}
+	}
+	assert.Contains(t, byName, "prog_first")
+	assert.Contains(t, byName, "prog_second")
+
+	for name, sym := range progSyms {
+		assert.Equal(t, int(sym.Size), len(byName[name].ProgData),
+			"%s: program data must equal its own symbol size, not the whole section", name)
+	}
+}
+
+// TestMultiProgramOneSectionWithSubprogRejected verifies the loader hard-errors
+// on the unsupported layout: multiple GLOBAL programs sharing one section that
+// also uses .text subprograms. BPF-to-BPF call offsets are relocated relative
+// to the whole program section, which does not match the per-program trimmed
+// bytecode the loader builds, so loading must fail loudly rather than emit
+// wrong call offsets.
+func TestMultiProgramOneSectionWithSubprogRejected(t *testing.T) {
+	m := setup(t, "../../test-data/tc.multi_prog_one_section_subprog.bpf.elf")
+	defer m.ctrl.Finish()
+	f, err := os.Open(m.path)
+	if !assert.NoError(t, err, "open test ELF") {
+		return
+	}
+	defer f.Close()
+
+	elfFile, err := elf.NewFile(f)
+	assert.NoError(t, err)
+	elfLoader := newElfLoader(elfFile, m.ebpf_maps, m.ebpf_progs, "test", nil)
+
+	err = elfLoader.parseSection()
+	assert.NoError(t, err)
+
+	mapData, err := elfLoader.parseMap(BpfCustomData{})
+	assert.NoError(t, err)
+
+	m.ebpf_maps.EXPECT().CreateBPFMap(gomock.Any()).Return(ebpf_maps.BpfMap{MapFD: 7}, nil).AnyTimes()
+	m.ebpf_maps.EXPECT().GetBPFmapInfo(gomock.Any()).Return(ebpf_maps.BpfMapInfo{Id: 100}, nil).AnyTimes()
+	m.ebpf_maps.EXPECT().PinMap(gomock.Any(), gomock.Any()).AnyTimes()
+	m.ebpf_maps.EXPECT().GetMapFromPinPath(gomock.Any()).AnyTimes()
+
+	loadedMaps, err := elfLoader.loadMap(mapData)
+	assert.NoError(t, err)
+
+	// parseProg must reject this layout instead of producing programs with
+	// incorrect BPF-to-BPF call offsets.
+	_, err = elfLoader.parseProg(loadedMaps)
+	assert.Error(t, err, "shared-section + .text layout must be rejected")
+}
+
+// TestMultiSubprogramWithDistinctSubprogsRejected documents a known limitation:
+// an ELF with multiple entry programs (separate program sections) that each
+// call a different .text subprogram is not supported. The loader appends the
+// entire combined .text to every program, so each program would carry
+// subprograms it never calls and the kernel verifier rejects the load with
+// "unreachable insn". Until per-program call-graph extraction is implemented,
+// the loader must reject this layout rather than emit bytecode the kernel will
+// refuse.
+func TestMultiSubprogramWithDistinctSubprogsRejected(t *testing.T) {
+	m := setup(t, "../../test-data/tc.multi_subprog.bpf.elf")
+	defer m.ctrl.Finish()
+	f, err := os.Open(m.path)
+	if !assert.NoError(t, err, "open test ELF") {
+		return
+	}
+	defer f.Close()
+
+	elfFile, err := elf.NewFile(f)
+	assert.NoError(t, err)
+	elfLoader := newElfLoader(elfFile, m.ebpf_maps, m.ebpf_progs, "test", nil)
+
+	assert.NoError(t, elfLoader.parseSection())
+
+	mapData, err := elfLoader.parseMap(BpfCustomData{})
+	assert.NoError(t, err)
+
+	m.ebpf_maps.EXPECT().CreateBPFMap(gomock.Any()).Return(ebpf_maps.BpfMap{MapFD: 7}, nil).AnyTimes()
+	m.ebpf_maps.EXPECT().GetBPFmapInfo(gomock.Any()).Return(ebpf_maps.BpfMapInfo{Id: 100}, nil).AnyTimes()
+	m.ebpf_maps.EXPECT().PinMap(gomock.Any(), gomock.Any()).AnyTimes()
+	m.ebpf_maps.EXPECT().GetMapFromPinPath(gomock.Any()).AnyTimes()
+
+	loadedMaps, err := elfLoader.loadMap(mapData)
+	assert.NoError(t, err)
+
+	// More than one entry program + .text subprograms -> must be rejected.
+	_, err = elfLoader.parseProg(loadedMaps)
+	assert.Error(t, err, "multiple entry programs with .text subprograms must be rejected")
+}
+
+// TestTextOnlyMapAssociation guards the fix where getRelocatedTextSection must
+// report maps referenced ONLY from within a .text subprogram as associated with
+// the owning program. The fixture's textonly_map is used solely inside the
+// __noinline subprogram (it appears in .rel.text, never in the entry program's
+// .reltc_cls), so the program's AssociatedMaps name table is built entirely
+// from the .text relocation pass. Before the fix, getRelocatedTextSection
+// patched the FD but discarded the name, leaving AssociatedMaps empty and
+// breaking callers that resolve maps by name.
+func TestTextOnlyMapAssociation(t *testing.T) {
+	m := setup(t, "../../test-data/tc.subprog_textonly_map.bpf.elf")
+	defer m.ctrl.Finish()
+	f, err := os.Open(m.path)
+	if !assert.NoError(t, err, "open test ELF") {
+		return
+	}
+	defer f.Close()
+
+	elfFile, err := elf.NewFile(f)
+	assert.NoError(t, err)
+	elfLoader := newElfLoader(elfFile, m.ebpf_maps, m.ebpf_progs, "test", nil)
+
+	assert.NoError(t, elfLoader.parseSection())
+	assert.NotNil(t, elfLoader.textSection)
+	assert.NotNil(t, elfLoader.reloSectionMap[uint32(elfLoader.textSectionIndex)])
+
+	mapData, err := elfLoader.parseMap(BpfCustomData{})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(mapData))
+
+	const textonlyFD, textonlyID = 5, 100
+	m.ebpf_maps.EXPECT().CreateBPFMap(gomock.Any()).Return(ebpf_maps.BpfMap{MapFD: textonlyFD}, nil).AnyTimes()
+	m.ebpf_maps.EXPECT().GetBPFmapInfo(gomock.Any()).Return(ebpf_maps.BpfMapInfo{Id: textonlyID}, nil).AnyTimes()
+	m.ebpf_maps.EXPECT().PinMap(gomock.Any(), gomock.Any()).AnyTimes()
+	// textonly_map is PIN_GLOBAL_NS, so loadMap resolves its ID via the pin path.
+	m.ebpf_maps.EXPECT().GetMapFromPinPath(gomock.Any()).Return(ebpf_maps.BpfMapInfo{Id: textonlyID}, nil).AnyTimes()
+
+	loadedMaps, err := elfLoader.loadMap(mapData)
+	assert.NoError(t, err)
+
+	parsedProgData, err := elfLoader.parseProg(loadedMaps)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(parsedProgData))
+
+	// The map is referenced only from .text, yet it MUST appear in the
+	// program's associated-map name table (keyed by map ID).
+	for _, progInput := range parsedProgData {
+		assert.Contains(t, progInput.AssociatedMaps, textonlyID,
+			"textonly_map (ID %d) must be associated with the prog even though it is referenced only from .text", textonlyID)
+		assert.Equal(t, "textonly_map", progInput.AssociatedMaps[textonlyID],
+			"associated map name should be textonly_map")
+	}
+}
+
+// TestSubprogramNoMapRelocation covers a .text subprogram that references no
+// maps: clang emits a non-empty .text but no .rel.text section. This exercises
+// the "No .rel.text relocation section found" path in getRelocatedTextSection,
+// where .text must still be read and appended to the program with no map
+// relocations applied.
+func TestSubprogramNoMapRelocation(t *testing.T) {
+	m := setup(t, "../../test-data/tc.subprog_nomap.bpf.elf")
+	defer m.ctrl.Finish()
+	f, err := os.Open(m.path)
+	if !assert.NoError(t, err, "open test ELF") {
+		return
+	}
+	defer f.Close()
+
+	elfFile, err := elf.NewFile(f)
+	assert.NoError(t, err)
+	elfLoader := newElfLoader(elfFile, m.ebpf_maps, m.ebpf_progs, "test", nil)
+
+	assert.NoError(t, elfLoader.parseSection())
+	assert.NotNil(t, elfLoader.textSection)
+	// .text exists with subprogram code but there is no .rel.text section.
+	assert.Nil(t, elfLoader.reloSectionMap[uint32(elfLoader.textSectionIndex)],
+		"fixture should have no .rel.text section")
+
+	textData, err := elfLoader.textSection.Data()
+	assert.NoError(t, err)
+	textSize := len(textData)
+	assert.Greater(t, textSize, 0, ".text should contain the subprogram")
+
+	mapData, err := elfLoader.parseMap(BpfCustomData{})
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(mapData))
+	loadedMaps, err := elfLoader.loadMap(mapData)
+	assert.NoError(t, err)
+
+	parsedProgData, err := elfLoader.parseProg(loadedMaps)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(parsedProgData))
+
+	// The subprogram must still be appended even though no .rel.text exists.
+	for _, progInput := range parsedProgData {
+		var tcProgSize int
+		for idx, entry := range elfLoader.progSectionMap {
+			if entry.progType == "tc_cls" {
+				d, _ := elfLoader.progSectionMap[idx].progSection.Data()
+				tcProgSize = len(d)
+				break
+			}
+		}
+		assert.Equal(t, tcProgSize+textSize, len(progInput.ProgData),
+			"program data should be tc_cls section + appended .text (no relocation)")
+	}
+}
+
+// TestSubprogramGlobalMapRelocation covers a map referenced only from inside a
+// .text subprogram and resolved via the sdkCache (the `sdkCache.Get` branch of
+// getRelocatedTextSection), NOT via the per-program loadedMaps argument. This is
+// the production scenario for a shared global map that was created by an earlier
+// LoadBpfFile call (global maps persist in sdkCache across loads) and is then
+// referenced by a later-loaded program's subprogram. We model it by seeding the
+// sdkCache and passing parseProg an empty loadedMaps, so the only way to resolve
+// the map FD inside .text is the cache.
+func TestSubprogramGlobalMapRelocation(t *testing.T) {
+	m := setup(t, "../../test-data/tc.subprog_globalmap.bpf.elf")
+	defer m.ctrl.Finish()
+	f, err := os.Open(m.path)
+	if !assert.NoError(t, err, "open test ELF") {
+		return
+	}
+	defer f.Close()
+
+	elfFile, err := elf.NewFile(f)
+	assert.NoError(t, err)
+	elfLoader := newElfLoader(elfFile, m.ebpf_maps, m.ebpf_progs, "", nil)
+
+	assert.NoError(t, elfLoader.parseSection())
+	assert.NotNil(t, elfLoader.reloSectionMap[uint32(elfLoader.textSectionIndex)],
+		".text should have a .rel.text map relocation")
+
+	// Seed the global cache as if this map were created by a previous load.
+	const globalFD = 4242
+	sdkCache.Set("global_subprog_map", globalFD)
+	defer sdkCache.Delete("global_subprog_map")
+
+	// Pass an EMPTY loadedMaps so the .text relocation cannot resolve the map
+	// from loadedMaps[name]; it must fall through to the sdkCache branch.
+	parsedProgData, err := elfLoader.parseProg(map[string]ebpf_maps.BpfMap{})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(parsedProgData))
+
+	// The global map FD (from sdkCache) must be patched into the
+	// BPF_LD_IMM_DW inside the appended .text.
+	const bpfLdImmDW = byte(unix.BPF_LD | unix.BPF_IMM | unix.BPF_DW)
+	for _, progInput := range parsedProgData {
+		var tcProgSize int
+		for idx, entry := range elfLoader.progSectionMap {
+			if entry.progType == "tc_cls" {
+				d, _ := elfLoader.progSectionMap[idx].progSection.Data()
+				tcProgSize = len(d)
+				break
+			}
+		}
+		mapLoadOffset := -1
+		for off := tcProgSize; off+16 <= len(progInput.ProgData); off += bpfInsDefSize {
+			if progInput.ProgData[off] == bpfLdImmDW {
+				mapLoadOffset = off
+				break
+			}
+		}
+		assert.NotEqual(t, -1, mapLoadOffset, ".text should contain a BPF_LD_IMM_DW map load")
+		gotFD := int32(binary.LittleEndian.Uint32(progInput.ProgData[mapLoadOffset+4 : mapLoadOffset+8]))
+		assert.Equal(t, int32(globalFD), gotFD,
+			"global map FD (from sdkCache) should be patched into the .text map load")
+	}
+}
+
+// TestSubprogramRealKernelLoad loads the .text subprogram fixtures into the
+// REAL kernel (no mocks): it creates the maps, applies .text relocations, and
+// the kernel verifier must accept the assembled bytecode. This is the strongest
+// guard for the .text feature -- the parse-level tests assert byte/metadata
+// transforms, but only a real load proves the relocated program actually
+// verifies and that prog->map association (built from the kernel FD query)
+// includes maps referenced only from .text. Requires root; skipped otherwise.
+func TestSubprogramRealKernelLoad(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root to create maps and load programs into the kernel")
+	}
+	assert.NoError(t, utils.Mount_bpf_fs())
+	defer utils.Unmount_bpf_fs()
+
+	tests := []struct {
+		name        string
+		elf         string
+		pinPrefix   string
+		wantProgs   int
+		wantMaps    int
+		wantMapName string // a map that must appear in the loaded prog's Maps
+	}{
+		{
+			name:        "single subprogram with map in .text",
+			elf:         "../../test-data/tc.subprog.bpf.elf",
+			pinPrefix:   "rk_subprog",
+			wantProgs:   1,
+			wantMaps:    1,
+			wantMapName: "aws_conntrack_map",
+		},
+		{
+			name:        "chained subprograms",
+			elf:         "../../test-data/tc.subprog_chain.bpf.elf",
+			pinPrefix:   "rk_chain",
+			wantProgs:   1,
+			wantMaps:    1,
+			wantMapName: "aws_conntrack_map",
+		},
+		{
+			name:        "map referenced only from .text subprogram",
+			elf:         "../../test-data/tc.subprog_textonly_map.bpf.elf",
+			pinPrefix:   "rk_textonly",
+			wantProgs:   1,
+			wantMaps:    1,
+			wantMapName: "textonly_map",
+		},
+		{
+			name:      "subprogram with no map relocation",
+			elf:       "../../test-data/tc.subprog_nomap.bpf.elf",
+			pinPrefix: "rk_nomap",
+			wantProgs: 1,
+			wantMaps:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := New(Config{NamespacedMaps: testNamespacedMaps})
+			progs, maps, err := client.LoadBpfFile(tt.elf, tt.pinPrefix)
+			// Best-effort cleanup of the pins this load created.
+			defer func() {
+				for p := range progs {
+					_ = os.Remove(p)
+				}
+				for _, mp := range maps {
+					if mp.MapMetaData.PinOptions != nil {
+						_ = os.Remove(mp.MapMetaData.PinOptions.PinPath)
+					}
+				}
+			}()
+
+			assert.NoError(t, err, "real-kernel load (verifier must accept relocated .text)")
+			assert.Equal(t, tt.wantProgs, len(progs), "loaded program count")
+			assert.Equal(t, tt.wantMaps, len(maps), "loaded map count")
+
+			if tt.wantMapName != "" {
+				// The map (including one referenced only from .text) must be
+				// associated with the loaded program via the kernel FD query.
+				found := false
+				for _, d := range progs {
+					if _, ok := d.Maps[tt.wantMapName]; ok {
+						found = true
+					}
+				}
+				assert.True(t, found,
+					"map %q must be associated with the loaded program", tt.wantMapName)
 			}
 		})
 	}

--- a/pkg/progs/loader.go
+++ b/pkg/progs/loader.go
@@ -15,11 +15,11 @@
 package progs
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"syscall"
 	"unsafe"
 
@@ -187,6 +187,16 @@ func (m *BpfProgram) UnPinProg(pinPath string) error {
 	return unix.Close(int(m.ProgFD))
 }
 
+// verifierLogString returns the verifier message up to the first NUL,
+// converting only that prefix (not the whole ~16 MiB NUL-padded buffer).
+func verifierLogString(logBuf []byte) string {
+	end := bytes.IndexByte(logBuf, 0)
+	if end < 0 {
+		end = len(logBuf)
+	}
+	return string(logBuf[:end])
+}
+
 func (m *BpfProgram) LoadProg(progMetaData CreateEBPFProgInput) (int, error) {
 
 	var prog_type uint32
@@ -232,11 +242,7 @@ func (m *BpfProgram) LoadProg(progMetaData CreateEBPFProgInput) (int, error) {
 	log.Infof("Load prog done with fd : %d errno: %d (%s) insnCnt: %d attrSize: %d progType: %d", int(fd), int(errno), errno.Error(), program.InsnCnt, unsafe.Sizeof(program), program.ProgType)
 	if errno != 0 {
 		// Surface the verifier log captured during the load above for diagnostics.
-		verifierLog := string(logBuf[:])
-		if idx := strings.IndexByte(verifierLog, 0); idx >= 0 {
-			verifierLog = verifierLog[:idx]
-		}
-		if len(verifierLog) > 0 {
+		if verifierLog := verifierLogString(logBuf); len(verifierLog) > 0 {
 			log.Infof("Verifier log: %s", verifierLog)
 		}
 		return -1, errno

--- a/pkg/progs/loader.go
+++ b/pkg/progs/loader.go
@@ -187,12 +187,6 @@ func (m *BpfProgram) UnPinProg(pinPath string) error {
 	return unix.Close(int(m.ProgFD))
 }
 
-func parseLogs(log []byte) []string {
-	logStr := string(log)
-	logs := strings.Split(logStr, "\n")
-	return logs
-}
-
 func (m *BpfProgram) LoadProg(progMetaData CreateEBPFProgInput) (int, error) {
 
 	var prog_type uint32
@@ -233,12 +227,17 @@ func (m *BpfProgram) LoadProg(progMetaData CreateEBPFProgInput) (int, error) {
 		unsafe.Sizeof(program))
 	runtime.KeepAlive(progMetaData.ProgData)
 	runtime.KeepAlive(license)
+	runtime.KeepAlive(logBuf)
 
-	log.Infof("Load prog done with fd : %d", int(fd))
+	log.Infof("Load prog done with fd : %d errno: %d (%s) insnCnt: %d attrSize: %d progType: %d", int(fd), int(errno), errno.Error(), program.InsnCnt, unsafe.Sizeof(program), program.ProgType)
 	if errno != 0 {
-		logArray := parseLogs(logBuf)
-		for _, str := range logArray {
-			fmt.Println(str)
+		// Surface the verifier log captured during the load above for diagnostics.
+		verifierLog := string(logBuf[:])
+		if idx := strings.IndexByte(verifierLog, 0); idx >= 0 {
+			verifierLog = verifierLog[:idx]
+		}
+		if len(verifierLog) > 0 {
+			log.Infof("Verifier log: %s", verifierLog)
 		}
 		return -1, errno
 	}

--- a/pkg/progs/loader_test.go
+++ b/pkg/progs/loader_test.go
@@ -1,0 +1,73 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+//limitations under the License.
+
+package progs
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestVerifierLogString verifies the log is returned up to the first NUL.
+func TestVerifierLogString(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []byte
+		want string
+	}{
+		{
+			name: "message then NUL padding",
+			in:   append([]byte("permission denied"), make([]byte, 1024)...),
+			want: "permission denied",
+		},
+		{
+			name: "no NUL (whole buffer is message)",
+			in:   []byte("full message no terminator"),
+			want: "full message no terminator",
+		},
+		{
+			name: "leading NUL yields empty string",
+			in:   []byte{0, 'x', 'y'},
+			want: "",
+		},
+		{
+			name: "empty buffer",
+			in:   []byte{},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := verifierLogString(tt.in)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestVerifierLogStringDoesNotCopyPadding ensures only the prefix is returned,
+// not the large NUL padding, when the buffer is mostly empty.
+func TestVerifierLogStringDoesNotCopyPadding(t *testing.T) {
+	const msg = "BPF program is too large"
+	buf := append([]byte(msg), make([]byte, 16*1024*1024)...) // 16 MiB of padding
+
+	got := verifierLogString(buf)
+
+	assert.Equal(t, msg, got)
+	assert.Equal(t, len(msg), len(got),
+		"returned string must be the prefix only, not the full padded buffer")
+	assert.False(t, strings.ContainsRune(got, 0), "result must not contain NUL bytes")
+}

--- a/test-data/tc.multi_prog_one_section.bpf.c
+++ b/test-data/tc.multi_prog_one_section.bpf.c
@@ -1,0 +1,62 @@
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+
+#define BPF_F_NO_PREALLOC 1
+#define PIN_GLOBAL_NS           2
+
+struct bpf_map_def_pvt {
+	__u32 type;
+	__u32 key_size;
+	__u32 value_size;
+	__u32 max_entries;
+	__u32 map_flags;
+	__u32 pinning;
+	__u32 inner_map_fd;
+};
+
+struct conntrack_key {
+   __u32 src_ip;
+};
+
+struct conntrack_value {
+   __u8 val[4];
+};
+
+struct bpf_map_def_pvt SEC("maps") shared_map = {
+    .type = BPF_MAP_TYPE_LRU_HASH,
+    .key_size = sizeof(struct conntrack_key),
+    .value_size = sizeof(struct conntrack_value),
+    .max_entries = 65536,
+    .pinning = PIN_GLOBAL_NS,
+};
+
+// Two GLOBAL programs placed in the SAME section ("tc_cls"). clang emits both
+// functions back-to-back into one PROGBITS section, each a global STT_FUNC
+// symbol with its own offset and size. The loader must slice each program by
+// its own symbol size; loading from a program's start to the end of the whole
+// section would make the first program swallow the second.
+SEC("tc_cls")
+int prog_first(struct __sk_buff *skb)
+{
+    struct conntrack_key key = {};
+    key.src_ip = 0x0a010164;
+    struct conntrack_value *val = bpf_map_lookup_elem(&shared_map, &key);
+    if (val)
+        return BPF_OK;
+    return BPF_DROP;
+}
+
+SEC("tc_cls")
+int prog_second(struct __sk_buff *skb)
+{
+    struct conntrack_key key = {};
+    key.src_ip = 0x0a010165;
+    struct conntrack_value *val = bpf_map_lookup_elem(&shared_map, &key);
+    if (val)
+        return BPF_DROP;
+    return BPF_OK;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/test-data/tc.multi_prog_one_section_subprog.bpf.c
+++ b/test-data/tc.multi_prog_one_section_subprog.bpf.c
@@ -1,0 +1,67 @@
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+
+#define BPF_F_NO_PREALLOC 1
+#define PIN_GLOBAL_NS           2
+
+struct bpf_map_def_pvt {
+	__u32 type;
+	__u32 key_size;
+	__u32 value_size;
+	__u32 max_entries;
+	__u32 map_flags;
+	__u32 pinning;
+	__u32 inner_map_fd;
+};
+
+struct conntrack_key {
+   __u32 src_ip;
+};
+
+struct conntrack_value {
+   __u8 val[4];
+};
+
+struct bpf_map_def_pvt SEC("maps") shared_map = {
+    .type = BPF_MAP_TYPE_LRU_HASH,
+    .key_size = sizeof(struct conntrack_key),
+    .value_size = sizeof(struct conntrack_value),
+    .max_entries = 65536,
+    .pinning = PIN_GLOBAL_NS,
+};
+
+// A __noinline helper lands in .text as a BPF-to-BPF subprogram.
+static __attribute__((noinline)) int lookup(__u32 src_ip)
+{
+    struct conntrack_key key = {};
+    key.src_ip = src_ip;
+    struct conntrack_value *val = bpf_map_lookup_elem(&shared_map, &key);
+    if (val)
+        return val->val[0];
+    return 0;
+}
+
+// Two GLOBAL programs in the SAME section ("tc_cls") that ALSO call a .text
+// subprogram. This is the unsupported layout: BPF-to-BPF call offsets are
+// relocated relative to the whole program section, which no longer matches the
+// per-program trimmed bytecode the loader builds. The loader must hard-error
+// rather than silently emit wrong call offsets.
+SEC("tc_cls")
+int prog_first(struct __sk_buff *skb)
+{
+    if (lookup(0x0a010164))
+        return BPF_OK;
+    return BPF_DROP;
+}
+
+SEC("tc_cls")
+int prog_second(struct __sk_buff *skb)
+{
+    if (lookup(0x0a010165))
+        return BPF_DROP;
+    return BPF_OK;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/test-data/tc.multi_subprog.bpf.c
+++ b/test-data/tc.multi_subprog.bpf.c
@@ -1,0 +1,94 @@
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+
+#define BPF_F_NO_PREALLOC 1
+#define PIN_GLOBAL_NS           2
+
+/* 
+Note: tc.multi_subprog is an ELF with multiple entry programs that each call a
+distinct .text subprogram. The loader does not support that layout (it appends
+the whole .text to every program); it is kept only as a fixture to assert the
+loader rejects it. See TestMultiSubprogramWithDistinctSubprogsRejected.
+*/
+
+struct bpf_map_def_pvt {
+	__u32 type;
+	__u32 key_size;
+	__u32 value_size;
+	__u32 max_entries;
+	__u32 map_flags;
+	__u32 pinning;
+	__u32 inner_map_fd;
+};
+
+struct conntrack_key {
+   __u32 src_ip;
+};
+
+struct conntrack_value {
+   __u8 val[4];
+};
+
+struct bpf_map_def_pvt SEC("maps") map_alpha = {
+    .type = BPF_MAP_TYPE_LRU_HASH,
+    .key_size = sizeof(struct conntrack_key),
+    .value_size = sizeof(struct conntrack_value),
+    .max_entries = 65536,
+    .pinning = PIN_GLOBAL_NS,
+};
+
+struct bpf_map_def_pvt SEC("maps") map_beta = {
+    .type = BPF_MAP_TYPE_LRU_HASH,
+    .key_size = sizeof(struct conntrack_key),
+    .value_size = sizeof(struct conntrack_value),
+    .max_entries = 65536,
+    .pinning = PIN_GLOBAL_NS,
+};
+
+/* Subprogram A: looks up map_alpha. Ends up in .text. */
+static __attribute__((noinline)) int lookup_alpha(__u32 src_ip)
+{
+    struct conntrack_key key = {};
+    key.src_ip = src_ip;
+
+    struct conntrack_value *val;
+    val = bpf_map_lookup_elem(&map_alpha, &key);
+    if (val)
+        return val->val[0];
+    return 0;
+}
+
+/* Subprogram B: looks up map_beta. Ends up in .text. */
+static __attribute__((noinline)) int lookup_beta(__u32 src_ip)
+{
+    struct conntrack_key key = {};
+    key.src_ip = src_ip;
+
+    struct conntrack_value *val;
+    val = bpf_map_lookup_elem(&map_beta, &key);
+    if (val)
+        return val->val[0];
+    return 0;
+}
+
+SEC("tc_cls")
+int handle_ingress(struct __sk_buff *skb)
+{
+    int result = lookup_alpha(0x0a010164);
+    if (result)
+        return BPF_OK;
+    return BPF_DROP;
+}
+
+SEC("xdp")
+int handle_xdp(struct xdp_md *ctx)
+{
+    int result = lookup_beta(0x0a010165);
+    if (result)
+        return XDP_PASS;
+    return XDP_DROP;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/test-data/tc.subprog.bpf.c
+++ b/test-data/tc.subprog.bpf.c
@@ -1,0 +1,60 @@
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+
+#define BPF_F_NO_PREALLOC 1
+#define PIN_GLOBAL_NS           2
+
+struct bpf_map_def_pvt {
+	__u32 type;
+	__u32 key_size;
+	__u32 value_size;
+	__u32 max_entries;
+	__u32 map_flags;
+	__u32 pinning;
+	__u32 inner_map_fd;
+};
+
+struct conntrack_key {
+   __u32 src_ip;
+   __u16 src_port;
+   __u32 dest_ip;
+   __u16 dest_port;
+   __u8  protocol;
+};
+
+struct conntrack_value {
+   __u8 val[4];
+};
+
+struct bpf_map_def_pvt SEC("maps") aws_conntrack_map = {
+    .type = BPF_MAP_TYPE_LRU_HASH,
+    .key_size = sizeof(struct conntrack_key),
+    .value_size = sizeof(struct conntrack_value),
+    .max_entries = 65536,
+    .pinning = PIN_GLOBAL_NS,
+};
+
+static __attribute__((noinline)) int lookup_conntrack(__u32 src_ip)
+{
+    struct conntrack_key key = {};
+    key.src_ip = src_ip;
+
+    struct conntrack_value *val;
+    val = bpf_map_lookup_elem(&aws_conntrack_map, &key);
+    if (val)
+        return val->val[0];
+    return 0;
+}
+
+SEC("tc_cls")
+int handle_ingress(struct __sk_buff *skb)
+{
+    int result = lookup_conntrack(0x0a010164);
+    if (result)
+        return BPF_OK;
+    return BPF_DROP;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/test-data/tc.subprog_badsection.bpf.c
+++ b/test-data/tc.subprog_badsection.bpf.c
@@ -1,0 +1,28 @@
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+
+#define PIN_GLOBAL_NS 2
+struct bpf_map_def_pvt { __u32 type; __u32 key_size; __u32 value_size; __u32 max_entries; __u32 map_flags; __u32 pinning; __u32 inner_map_fd; };
+struct bpf_map_def_pvt SEC("maps") m = {
+    .type = BPF_MAP_TYPE_ARRAY, .key_size = sizeof(__u32), .value_size = sizeof(__u64),
+    .max_entries = 1, .pinning = PIN_GLOBAL_NS,
+};
+
+// A __noinline subprogram in a CUSTOM section (not .text); the call relocates
+// against a symbol outside .text, which the loader does not append.
+__attribute__((noinline)) __attribute__((section("mysubprogs")))
+int helper_custom(__u32 x) {
+    __u32 k = x & 0;
+    __u64 *v = bpf_map_lookup_elem(&m, &k);
+    if (v && *v > 10) return 2;
+    return 1;
+}
+
+SEC("tc_cls")
+int handle_ingress(struct __sk_buff *skb) {
+    if (helper_custom(skb->len)) return BPF_OK;
+    return BPF_DROP;
+}
+char _license[] SEC("license") = "GPL";

--- a/test-data/tc.subprog_chain.bpf.c
+++ b/test-data/tc.subprog_chain.bpf.c
@@ -1,0 +1,69 @@
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+
+#define BPF_F_NO_PREALLOC 1
+#define PIN_GLOBAL_NS           2
+
+struct bpf_map_def_pvt {
+	__u32 type;
+	__u32 key_size;
+	__u32 value_size;
+	__u32 max_entries;
+	__u32 map_flags;
+	__u32 pinning;
+	__u32 inner_map_fd;
+};
+
+struct conntrack_key {
+   __u32 src_ip;
+   __u16 src_port;
+   __u32 dest_ip;
+   __u16 dest_port;
+   __u8  protocol;
+};
+
+struct conntrack_value {
+   __u8 val[4];
+};
+
+struct bpf_map_def_pvt SEC("maps") aws_conntrack_map = {
+    .type = BPF_MAP_TYPE_LRU_HASH,
+    .key_size = sizeof(struct conntrack_key),
+    .value_size = sizeof(struct conntrack_value),
+    .max_entries = 65536,
+    .pinning = PIN_GLOBAL_NS,
+};
+
+/* Subprogram B: does the actual map lookup.
+ * This is called by subprogram A, exercising .text -> .text calls. */
+static __attribute__((noinline)) int do_lookup(__u32 src_ip)
+{
+    struct conntrack_key key = {};
+    key.src_ip = src_ip;
+
+    struct conntrack_value *val;
+    val = bpf_map_lookup_elem(&aws_conntrack_map, &key);
+    if (val)
+        return val->val[0];
+    return 0;
+}
+
+/* Subprogram A: calls subprogram B.
+ * Both are __noinline and end up in .text section. */
+static __attribute__((noinline)) int lookup_conntrack(__u32 src_ip)
+{
+    return do_lookup(src_ip);
+}
+
+SEC("tc_cls")
+int handle_ingress(struct __sk_buff *skb)
+{
+    int result = lookup_conntrack(0x0a010164);
+    if (result)
+        return BPF_OK;
+    return BPF_DROP;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/test-data/tc.subprog_globalmap.bpf.c
+++ b/test-data/tc.subprog_globalmap.bpf.c
@@ -1,0 +1,59 @@
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+
+#define BPF_F_NO_PREALLOC 1
+#define PIN_GLOBAL_NS           2
+
+struct bpf_map_def_pvt {
+	__u32 type;
+	__u32 key_size;
+	__u32 value_size;
+	__u32 max_entries;
+	__u32 map_flags;
+	__u32 pinning;
+	__u32 inner_map_fd;
+};
+
+struct conntrack_key {
+   __u32 src_ip;
+};
+
+struct conntrack_value {
+   __u8 val[4];
+};
+
+// A GLOBAL (non-namespaced) map referenced ONLY from inside the .text
+// subprogram. With the SDK treating it as global, its FD is resolved from the
+// sdkCache during .text relocation (the `sdkCache.Get` branch in
+// getRelocatedTextSection), exercising the global-map .text relocation path
+// that the production NPA agent actually hits (aws_conntrack_map / policy_events
+// are global maps used inside subprograms).
+struct bpf_map_def_pvt SEC("maps") global_subprog_map = {
+    .type = BPF_MAP_TYPE_LRU_HASH,
+    .key_size = sizeof(struct conntrack_key),
+    .value_size = sizeof(struct conntrack_value),
+    .max_entries = 65536,
+    .pinning = PIN_GLOBAL_NS,
+};
+
+static __attribute__((noinline)) int lookup_global(__u32 src_ip)
+{
+    struct conntrack_key key = {};
+    key.src_ip = src_ip;
+    struct conntrack_value *val = bpf_map_lookup_elem(&global_subprog_map, &key);
+    if (val)
+        return val->val[0];
+    return 0;
+}
+
+SEC("tc_cls")
+int handle_ingress(struct __sk_buff *skb)
+{
+    if (lookup_global(0x0a010164))
+        return BPF_OK;
+    return BPF_DROP;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/test-data/tc.subprog_nomap.bpf.c
+++ b/test-data/tc.subprog_nomap.bpf.c
@@ -1,0 +1,30 @@
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+
+// A __noinline subprogram that touches NO map and needs no relocation. clang
+// emits it into .text but produces NO .rel.text section (nothing to relocate
+// inside .text). This exercises the "No .rel.text relocation section found"
+// path in getRelocatedTextSection: .text is non-empty and must still be read
+// and appended, but with no map relocations applied.
+static __attribute__((noinline)) int classify_len(__u32 len)
+{
+    if (len > 1500)
+        return 3;
+    if (len > 500)
+        return 2;
+    if (len > 0)
+        return 1;
+    return 0;
+}
+
+SEC("tc_cls")
+int handle_ingress(struct __sk_buff *skb)
+{
+    if (classify_len(skb->len) > 0)
+        return BPF_OK;
+    return BPF_DROP;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/test-data/tc.subprog_textonly_map.bpf.c
+++ b/test-data/tc.subprog_textonly_map.bpf.c
@@ -1,0 +1,60 @@
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+
+#define BPF_F_NO_PREALLOC 1
+#define PIN_GLOBAL_NS           2
+
+struct bpf_map_def_pvt {
+	__u32 type;
+	__u32 key_size;
+	__u32 value_size;
+	__u32 max_entries;
+	__u32 map_flags;
+	__u32 pinning;
+	__u32 inner_map_fd;
+};
+
+struct conntrack_key {
+   __u32 src_ip;
+};
+
+struct conntrack_value {
+   __u8 val[4];
+};
+
+// This map is referenced ONLY from inside the __noinline subprogram (i.e. only
+// from the .text section), never from the entry program section. It exercises
+// the path where getRelocatedTextSection must report the map as associated with
+// the owning program; otherwise the program's AssociatedMaps name table misses
+// it (the bug fixed in commit that added textAssociatedMaps).
+struct bpf_map_def_pvt SEC("maps") textonly_map = {
+    .type = BPF_MAP_TYPE_LRU_HASH,
+    .key_size = sizeof(struct conntrack_key),
+    .value_size = sizeof(struct conntrack_value),
+    .max_entries = 65536,
+    .pinning = PIN_GLOBAL_NS,
+};
+
+// Subprogram lands in .text and is the ONLY place textonly_map is used.
+static __attribute__((noinline)) int lookup_textonly(__u32 src_ip)
+{
+    struct conntrack_key key = {};
+    key.src_ip = src_ip;
+    struct conntrack_value *val = bpf_map_lookup_elem(&textonly_map, &key);
+    if (val)
+        return val->val[0];
+    return 0;
+}
+
+// Entry program references NO map directly; it only calls the subprogram.
+SEC("tc_cls")
+int handle_ingress(struct __sk_buff *skb)
+{
+    if (lookup_textonly(0x0a010164))
+        return BPF_OK;
+    return BPF_DROP;
+}
+
+char _license[] SEC("license") = "GPL";


### PR DESCRIPTION
Support __noinline BPF-to-BPF subprograms emitted by clang into the .text section. The loader now:

- reads the .text section and applies map-FD relocations from .rel.text to instructions inside subprograms
- appends .text after each program section and fixes up BPF_CALL instructions so call offsets point at the appended subprograms
- reports maps referenced only from .text as associated with the owning program (so callers that look maps up by name find them)
- slices each program by its own symbol size, so multiple global programs sharing one ELF section do not bleed into each other
- rejects the unsupported layout of multiple entry programs that each call distinct .text subprograms (the whole .text is appended to every program, which would create unreachable subprograms the verifier rejects); fail loud instead of emitting bad bytecode

Tests cover single subprogram, chained subprograms, multiple programs in one section, and the rejection paths. Test-data BPF sources added for each case.

*Issue #, if available:*

*Description of changes:*


Testing
- WIP

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
