### PR TITLE
Tail call support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,9 @@ TARGETS := \
 		  $(TESTDATADIR)/tc.subprog_badsection \
 		  $(TESTDATADIR)/tc.multi_subprog \
 		  $(TESTDATADIR)/tc.multi_prog_one_section \
-		  $(TESTDATADIR)/tc.multi_prog_one_section_subprog
+		  $(TESTDATADIR)/tc.multi_prog_one_section_subprog \
+		  $(TESTDATADIR)/tc.tailcall \
+		  $(TESTDATADIR)/tc.tailcall_target
 
 %.bpf.elf: %.bpf.c
 	$(CLANG) $(CLANG_INCLUDE) $(BPF_CFLAGS) -c $< -o $@

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ goebpfelfparser "github.com/aws/aws-ebpf-sdk-go/pkg/elfparser"
 3. Load the elf -
 
 ```
-goebpfelfparser.LoadBpfFile(<ELF file>, <custom pin path>)
+sdkClient := goebpfelfparser.New(goebpfelfparser.Config{})
+sdkClient.LoadBpfFile(<ELF file>, <custom pin path>)
 ```
 
 On a successful load, SDK returns -
@@ -101,6 +102,77 @@ struct bpf_map_def_pvt {
 	__u32 inner_map_fd;
 };
 ```
+
+## How to use tail calls (BPF_MAP_TYPE_PROG_ARRAY)?
+
+A `BPF_MAP_TYPE_PROG_ARRAY` map (declared like any other map above) and a
+`bpf_tail_call()` call in your BPF C source need no special ELF-loader
+handling from the SDK: `bpf_tail_call()` is an ordinary helper call, and the
+prog array map FD is applied through the same relocation path as any other
+map reference. What the ELF loader cannot do for you is populate the map,
+since that requires the FDs of the *target* programs, which only exist after
+they've been loaded.
+
+### Example: wiring an EDT rate-limiter as a tail-call target
+
+Suppose you have a policy program (`tc.v4egress.bpf.c`) that tail-calls into
+an EDT program (`edt.v4egress.bpf.c`) at index 1. Both ELFs declare the same
+`tc_jump_table` prog array with `PIN_GLOBAL_NS`, so the kernel shares a
+single map instance across loads.
+
+1. Load the caller ELF (the program that issues `bpf_tail_call`). This
+   creates the prog array map and loads the caller program:
+
+```go
+sdkClient := goebpfelfparser.New(goebpfelfparser.Config{})
+callerProgs, maps, err := sdkClient.LoadBpfFile("tc.v4egress.bpf.elf", "egress")
+```
+
+2. Load the tail-call target from its own ELF. Because the prog array map
+   uses `PIN_GLOBAL_NS`, both ELFs share the same kernel map instance via
+   pinning — there is no need to pass the map FD across loads manually:
+
+```go
+targetProgs, _, err := sdkClient.LoadBpfFile("edt.v4egress.bpf.elf", "edt")
+```
+
+3. Look up the prog array map by name from the caller's maps, find the
+   target program's FD from the second load, and populate the tail-call slot.
+
+   `LoadBpfFile` returns programs keyed by their **full pin path**
+   (e.g. `/sys/fs/bpf/globals/aws/programs/edt_handle_edt_egress`), so you
+   need to iterate and match the C function name:
+
+```go
+progArray := maps["tc_jump_table"]
+for pinPath, data := range targetProgs {
+    if strings.Contains(pinPath, "handle_edt_egress") {
+        err = progArray.UpdateProgArrayEntry(1 /* TC_TAIL_CALL_EDT_EGRESS */, data.Program.ProgFD)
+        break
+    }
+}
+```
+
+### API reference
+
+`UpdateProgArrayEntry` rejects maps that aren't `BPF_MAP_TYPE_PROG_ARRAY` and
+negative FDs up front, rather than surfacing an opaque `EINVAL` from the
+kernel. To remove a slot (so a tail call to that index falls through instead
+of jumping), use `progArray.DeleteProgArrayEntry(index)`.
+
+### Future improvements
+
+The current API requires callers to iterate the returned program map and
+match pin paths by substring to find a target program. Two planned
+improvements would reduce this boilerplate:
+
+- **`FindProgByFunc(progs map[string]BpfData, funcName string) (BpfData, bool)`** —
+  a lookup helper that finds a loaded program by its C function name, removing
+  the need for manual iteration and `strings.Contains` matching.
+
+- **`LoadAndWireTailCall(targetELF, pinPrefix, funcName string, progArray BpfMap, index uint32)`** —
+  a single-call method that loads a target ELF and inserts the named program
+  into a prog array slot, collapsing steps 2–3 above into one operation.
 
 ## How to debug SDK issues?
 

--- a/pkg/maps/loader.go
+++ b/pkg/maps/loader.go
@@ -340,6 +340,55 @@ func (m *BpfMap) DeleteMapEntry(key uintptr) error {
 	return nil
 }
 
+// isProgArray checks that this map is a BPF_MAP_TYPE_PROG_ARRAY, since tail
+// call helpers below only make sense for that map type.
+func (m *BpfMap) isProgArray() error {
+	if constdef.EBPFMapType(m.MapMetaData.Type) != constdef.BPF_MAP_TYPE_PROG_ARRAY {
+		return fmt.Errorf("map %q is type %d, not BPF_MAP_TYPE_PROG_ARRAY", m.MapMetaData.Name, m.MapMetaData.Type)
+	}
+	return nil
+}
+
+// UpdateProgArrayEntry sets tail-call slot `index` of a BPF_MAP_TYPE_PROG_ARRAY
+// map to `progFD`, so a bpf_tail_call(ctx, &map, index) in another program
+// jumps into it. Key and value are heap-allocated so their addresses remain
+// stable across potential stack growth when entering CreateUpdateMapEntry.
+func (m *BpfMap) UpdateProgArrayEntry(index uint32, progFD int) error {
+	if err := m.isProgArray(); err != nil {
+		return fmt.Errorf("UpdateProgArrayEntry: %w", err)
+	}
+	if progFD < 0 {
+		return fmt.Errorf("UpdateProgArrayEntry: invalid program FD %d", progFD)
+	}
+
+	key := new(uint32)
+	*key = index
+	value := new(uint32)
+	*value = uint32(progFD)
+	err := m.CreateUpdateMapEntry(uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(value)), uint64(constdef.BPF_ANY))
+	runtime.KeepAlive(key)
+	runtime.KeepAlive(value)
+	return err
+}
+
+// DeleteProgArrayEntry clears tail-call slot `index`. A bpf_tail_call() to
+// that index afterwards just falls through, same as a normal cache miss.
+// Key is heap-allocated so its address remains stable across stack growth.
+func (m *BpfMap) DeleteProgArrayEntry(index uint32) error {
+	if err := m.isProgArray(); err != nil {
+		return fmt.Errorf("DeleteProgArrayEntry: %w", err)
+	}
+
+	key := new(uint32)
+	*key = index
+	err := m.DeleteMapEntry(uintptr(unsafe.Pointer(key)))
+	runtime.KeepAlive(key)
+	if err != nil {
+		return fmt.Errorf("DeleteProgArrayEntry index %d: %w", *key, err)
+	}
+	return nil
+}
+
 // To get the first entry pass key as `nil`
 func (m *BpfMap) GetFirstMapEntry(nextKey uintptr) error {
 	return m.GetNextMapEntry(uintptr(unsafe.Pointer(nil)), nextKey)

--- a/pkg/maps/loader_test.go
+++ b/pkg/maps/loader_test.go
@@ -1,0 +1,151 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+//limitations under the License.
+
+package maps_test
+
+import (
+	"os"
+	"testing"
+	"unsafe"
+
+	constdef "github.com/aws/aws-ebpf-sdk-go/pkg/constants"
+	"github.com/aws/aws-ebpf-sdk-go/pkg/maps"
+	"github.com/aws/aws-ebpf-sdk-go/pkg/progs"
+	"github.com/aws/aws-ebpf-sdk-go/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
+)
+
+func TestUpdateProgArrayEntryRejectsWrongMapType(t *testing.T) {
+	m := &maps.BpfMap{MapMetaData: maps.CreateEBPFMapInput{
+		Name: "not_a_prog_array",
+		Type: constdef.BPF_MAP_TYPE_HASH.Index(),
+	}}
+	assert.Error(t, m.UpdateProgArrayEntry(0, 3))
+}
+
+func TestDeleteProgArrayEntryRejectsWrongMapType(t *testing.T) {
+	m := &maps.BpfMap{MapMetaData: maps.CreateEBPFMapInput{
+		Name: "not_a_prog_array",
+		Type: constdef.BPF_MAP_TYPE_ARRAY.Index(),
+	}}
+	assert.Error(t, m.DeleteProgArrayEntry(0))
+}
+
+// A caller-supplied FD of -1 (e.g. forwarding a failed LoadProg result
+// without checking it) should be rejected, not written into the map as-is.
+func TestUpdateProgArrayEntryRejectsNegativeFD(t *testing.T) {
+	m := &maps.BpfMap{MapMetaData: maps.CreateEBPFMapInput{
+		Name: "prog_array",
+		Type: constdef.BPF_MAP_TYPE_PROG_ARRAY.Index(),
+	}}
+	assert.Error(t, m.UpdateProgArrayEntry(0, -1))
+}
+
+// buildTrivialXDPProg assembles `return <retval>;` by hand (mov r0, retval;
+// exit) so tests can load a real program without needing clang/libbpf to
+// compile one.
+func buildTrivialXDPProg(retval int32) []byte {
+	movR0 := utils.BPFInsn{Code: unix.BPF_ALU64 | unix.BPF_MOV | unix.BPF_K, DstReg: 0, Imm: retval}
+	exit := utils.BPFInsn{Code: unix.BPF_JMP | unix.BPF_EXIT}
+	return append(movR0.ConvertBPFInstructionToByteStream(), exit.ConvertBPFInstructionToByteStream()...)
+}
+
+// loadTrivialXDPProg loads buildTrivialXDPProg(retval) under name, and
+// registers cleanup so callers don't have to repeat the close+unpin dance
+// at every call site.
+func loadTrivialXDPProg(t *testing.T, progApi *progs.BpfProgram, name string, retval int32) int {
+	t.Helper()
+	pinPath := "/sys/fs/bpf/globals/aws/programs/" + name
+	fd, err := progApi.LoadProg(progs.CreateEBPFProgInput{
+		ProgType:   "xdp",
+		ProgData:   buildTrivialXDPProg(retval),
+		LicenseStr: "GPL",
+		PinPath:    pinPath,
+		InsDefSize: 8,
+	})
+	assert.NoError(t, err)
+	t.Cleanup(func() {
+		unix.Close(fd)
+		progApi.UnPinProg(pinPath)
+	})
+	return fd
+}
+
+// readProgArraySlot looks up a tail-call slot the way GetMapEntry requires:
+// raw uintptr-backed pointers to a fixed-size key/value.
+func readProgArraySlot(progArray maps.BpfMap, index uint32) (uint32, error) {
+	key, value := index, uint32(0)
+	err := progArray.GetMapEntry(uintptr(unsafe.Pointer(&key)), uintptr(unsafe.Pointer(&value)))
+	return value, err
+}
+
+// TestProgArrayRealKernelRoundTrip exercises the same flow an application
+// uses to wire up bpf_tail_call() targets: load the target programs, then
+// point each tail-call index at the right program FD. It creates a real
+// BPF_MAP_TYPE_PROG_ARRAY map and two trivial XDP programs against the
+// running kernel, populates two slots, reads them back, and deletes one.
+//
+// Requires root and a bpf-capable kernel, same as the other real-kernel
+// tests in this SDK; skipped otherwise.
+func TestProgArrayRealKernelRoundTrip(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root to create maps and load programs into the kernel")
+	}
+
+	utils.Mount_bpf_fs()
+	t.Cleanup(func() { utils.Unmount_bpf_fs() })
+
+	bpfMapApi := &maps.BpfMap{}
+	progArray, err := bpfMapApi.CreateBPFMap(maps.CreateEBPFMapInput{
+		Name:       "test_prog_array",
+		Type:       constdef.BPF_MAP_TYPE_PROG_ARRAY.Index(),
+		KeySize:    4,
+		ValueSize:  4,
+		MaxEntries: 4,
+	})
+	assert.NoError(t, err)
+	t.Cleanup(func() { unix.Close(int(progArray.MapFD)) })
+
+	bpfProgApi := &progs.BpfProgram{}
+	dropFD := loadTrivialXDPProg(t, bpfProgApi, "test_tailcall_drop", 1) // XDP_DROP
+	passFD := loadTrivialXDPProg(t, bpfProgApi, "test_tailcall_pass", 2) // XDP_PASS
+
+	assert.NoError(t, progArray.UpdateProgArrayEntry(0, dropFD))
+	assert.NoError(t, progArray.UpdateProgArrayEntry(1, passFD))
+
+	// A prog array lookup returns a program ID, not the FD we inserted, so
+	// compare against GetBPFprogInfo's ID rather than the FD itself. This
+	// needs progs.GetBPFprogInfo specifically: BPF_OBJ_GET_INFO_BY_FD returns
+	// a different struct layout for a program FD than for a map FD, and this
+	// package's own GetBPFmapInfo assumes the map layout.
+	dropInfo, err := progs.GetBPFprogInfo(dropFD)
+	assert.NoError(t, err)
+	passInfo, err := progs.GetBPFprogInfo(passFD)
+	assert.NoError(t, err)
+
+	gotDrop, err := readProgArraySlot(progArray, 0)
+	assert.NoError(t, err)
+	assert.Equal(t, dropInfo.ID, gotDrop)
+
+	gotPass, err := readProgArraySlot(progArray, 1)
+	assert.NoError(t, err)
+	assert.Equal(t, passInfo.ID, gotPass)
+
+	// After deleting a slot, a tail call to it should miss - same as the
+	// kernel's own behavior for an empty slot.
+	assert.NoError(t, progArray.DeleteProgArrayEntry(0))
+	_, err = readProgArraySlot(progArray, 0)
+	assert.Error(t, err)
+}

--- a/pkg/maps/mocks/ebpf_mocks.go
+++ b/pkg/maps/mocks/ebpf_mocks.go
@@ -133,6 +133,7 @@ func (mr *MockBpfMapAPIsMockRecorder) DeleteMapEntry(arg0 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMapEntry", reflect.TypeOf((*MockBpfMapAPIs)(nil).DeleteMapEntry), arg0)
 }
 
+
 // GetBPFmapInfo mocks base method.
 func (m *MockBpfMapAPIs) GetBPFmapInfo(arg0 uint32) (maps.BpfMapInfo, error) {
 	m.ctrl.T.Helper()
@@ -246,3 +247,4 @@ func (mr *MockBpfMapAPIsMockRecorder) UpdateMapEntry(arg0, arg1 interface{}) *go
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMapEntry", reflect.TypeOf((*MockBpfMapAPIs)(nil).UpdateMapEntry), arg0, arg1)
 }
+

--- a/test-data/tc.tailcall.bpf.c
+++ b/test-data/tc.tailcall.bpf.c
@@ -1,0 +1,41 @@
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+
+#define BPF_MAP_TYPE_PROG_ARRAY 3
+#define PIN_GLOBAL_NS           2
+
+struct bpf_map_def_pvt {
+	__u32 type;
+	__u32 key_size;
+	__u32 value_size;
+	__u32 max_entries;
+	__u32 map_flags;
+	__u32 pinning;
+	__u32 inner_map_fd;
+};
+
+struct bpf_map_def_pvt SEC("maps") tailcall_map = {
+	.type = BPF_MAP_TYPE_PROG_ARRAY,
+	.key_size = sizeof(__u32),
+	.value_size = sizeof(__u32),
+	.max_entries = 4,
+	.pinning = PIN_GLOBAL_NS,
+};
+
+SEC("tc_cls")
+int handle_ingress(struct __sk_buff *skb)
+{
+	bpf_tail_call(skb, &tailcall_map, 0);
+	return BPF_OK;
+}
+
+SEC("tc_cls")
+int handle_egress(struct __sk_buff *skb)
+{
+	bpf_tail_call(skb, &tailcall_map, 1);
+	return BPF_DROP;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/test-data/tc.tailcall_target.bpf.c
+++ b/test-data/tc.tailcall_target.bpf.c
@@ -1,0 +1,18 @@
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+
+SEC("tc_cls")
+int tailcall_target_drop(struct __sk_buff *skb)
+{
+	return BPF_DROP;
+}
+
+SEC("tc_cls")
+int tailcall_target_pass(struct __sk_buff *skb)
+{
+	return BPF_OK;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/test/c/tc.tailcall.bpf.c
+++ b/test/c/tc.tailcall.bpf.c
@@ -1,0 +1,41 @@
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+
+#define BPF_MAP_TYPE_PROG_ARRAY 3
+#define PIN_GLOBAL_NS           2
+
+struct bpf_map_def_pvt {
+	__u32 type;
+	__u32 key_size;
+	__u32 value_size;
+	__u32 max_entries;
+	__u32 map_flags;
+	__u32 pinning;
+	__u32 inner_map_fd;
+};
+
+struct bpf_map_def_pvt SEC("maps") tailcall_map = {
+	.type = BPF_MAP_TYPE_PROG_ARRAY,
+	.key_size = sizeof(__u32),
+	.value_size = sizeof(__u32),
+	.max_entries = 4,
+	.pinning = PIN_GLOBAL_NS,
+};
+
+SEC("tc_cls")
+int handle_ingress(struct __sk_buff *skb)
+{
+	bpf_tail_call(skb, &tailcall_map, 0);
+	return BPF_OK;
+}
+
+SEC("tc_cls")
+int handle_egress(struct __sk_buff *skb)
+{
+	bpf_tail_call(skb, &tailcall_map, 1);
+	return BPF_DROP;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/test/c/tc.tailcall_target.bpf.c
+++ b/test/c/tc.tailcall_target.bpf.c
@@ -1,0 +1,18 @@
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+
+SEC("tc_cls")
+int tailcall_target_drop(struct __sk_buff *skb)
+{
+	return BPF_DROP;
+}
+
+SEC("tc_cls")
+int tailcall_target_pass(struct __sk_buff *skb)
+{
+	return BPF_OK;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/test/main.go
+++ b/test/main.go
@@ -11,6 +11,8 @@ import (
 	"unsafe"
 
 	goelf "github.com/aws/aws-ebpf-sdk-go/pkg/elfparser"
+	ebpf_maps "github.com/aws/aws-ebpf-sdk-go/pkg/maps"
+	ebpf_progs "github.com/aws/aws-ebpf-sdk-go/pkg/progs"
 	ebpf_tc "github.com/aws/aws-ebpf-sdk-go/pkg/tc"
 	"github.com/fatih/color"
 )
@@ -64,6 +66,7 @@ func main() {
 		{Name: "Test updating Map size", Func: TestLoadMapWithCustomSize},
 		{Name: "Test bulk Map operations", Func: TestBulkMapOperations},
 		{Name: "Test bulk refresh Map operations", Func: TestBulkRefreshMapOperations},
+		{Name: "Test tail call prog array", Func: TestTailCallProgArray},
 	}
 
 	testSummary := make(map[string]string)
@@ -482,5 +485,187 @@ func TestBulkRefreshMapOperations() error {
 	}
 	fmt.Println("Updated 32K entries successfully")
 
+	return nil
+}
+
+func TestTailCallProgArray() error {
+	// Step 1: Load the tailcall BPF program which contains a BPF_MAP_TYPE_PROG_ARRAY
+	gosdkClient := goelf.New(goelf.Config{})
+	progInfo, loadedMaps, err := gosdkClient.LoadBpfFile("c/tc.tailcall.bpf.elf", "tailcall")
+	if err != nil {
+		fmt.Println("Load tailcall BPF failed", "err:", err)
+		return err
+	}
+
+	fmt.Println("Loaded tailcall programs:")
+	for pinPath, _ := range progInfo {
+		fmt.Println("  Prog Pin Path: ", pinPath)
+	}
+	fmt.Println("Loaded tailcall maps:")
+	for mapName, _ := range loadedMaps {
+		fmt.Println("  Map Name: ", mapName)
+	}
+
+	// Step 2: Verify we got the prog array map
+	progArrayMap, ok := loadedMaps["tailcall_map"]
+	if !ok {
+		return fmt.Errorf("tailcall_map not found in loaded maps")
+	}
+	fmt.Println("Found tailcall_map with FD:", progArrayMap.MapFD)
+
+	// Step 3: Load the tail call target programs
+	targetProgInfo, _, err := gosdkClient.LoadBpfFile("c/tc.tailcall_target.bpf.elf", "target")
+	if err != nil {
+		fmt.Println("Load tailcall target BPF failed", "err:", err)
+		return err
+	}
+
+	fmt.Println("Loaded target programs:")
+	for pinPath, _ := range targetProgInfo {
+		fmt.Println("  Target Prog Pin Path: ", pinPath)
+	}
+
+	// Step 4: Get program FDs for the targets
+	dropFD, passFD := -1, -1
+	for pinPath, data := range targetProgInfo {
+		switch {
+		case strings.Contains(pinPath, "tailcall_target_drop"):
+			dropFD = data.Program.ProgFD
+			fmt.Println("  Drop target FD:", dropFD)
+		case strings.Contains(pinPath, "tailcall_target_pass"):
+			passFD = data.Program.ProgFD
+			fmt.Println("  Pass target FD:", passFD)
+		}
+	}
+
+	if dropFD < 0 || passFD < 0 {
+		return fmt.Errorf("failed to find target program FDs: dropFD=%d passFD=%d", dropFD, passFD)
+	}
+
+	// Step 5: Test UpdateProgArrayEntry - insert tail call targets into prog array
+	fmt.Println("Inserting drop program into slot 0...")
+	err = progArrayMap.UpdateProgArrayEntry(0, dropFD)
+	if err != nil {
+		fmt.Println("UpdateProgArrayEntry slot 0 failed:", err)
+		return err
+	}
+
+	fmt.Println("Inserting pass program into slot 1...")
+	err = progArrayMap.UpdateProgArrayEntry(1, passFD)
+	if err != nil {
+		fmt.Println("UpdateProgArrayEntry slot 1 failed:", err)
+		return err
+	}
+
+	// Step 6: Verify the prog array entries by reading them back
+	// Prog array lookup returns program IDs (not FDs)
+	dropProgInfo, err := ebpf_progs.GetBPFprogInfo(dropFD)
+	if err != nil {
+		fmt.Println("GetBPFprogInfo for drop failed:", err)
+		return err
+	}
+	passProgInfo, err := ebpf_progs.GetBPFprogInfo(passFD)
+	if err != nil {
+		fmt.Println("GetBPFprogInfo for pass failed:", err)
+		return err
+	}
+
+	key0 := uint32(0)
+	val0 := uint32(0)
+	err = progArrayMap.GetMapEntry(uintptr(unsafe.Pointer(&key0)), uintptr(unsafe.Pointer(&val0)))
+	if err != nil {
+		fmt.Println("GetMapEntry for slot 0 failed:", err)
+		return err
+	}
+	if val0 != dropProgInfo.ID {
+		return fmt.Errorf("slot 0: expected prog ID %d, got %d", dropProgInfo.ID, val0)
+	}
+	fmt.Printf("Slot 0 verified: prog ID %d matches drop program\n", val0)
+
+	key1 := uint32(1)
+	val1 := uint32(0)
+	err = progArrayMap.GetMapEntry(uintptr(unsafe.Pointer(&key1)), uintptr(unsafe.Pointer(&val1)))
+	if err != nil {
+		fmt.Println("GetMapEntry for slot 1 failed:", err)
+		return err
+	}
+	if val1 != passProgInfo.ID {
+		return fmt.Errorf("slot 1: expected prog ID %d, got %d", passProgInfo.ID, val1)
+	}
+	fmt.Printf("Slot 1 verified: prog ID %d matches pass program\n", val1)
+
+	// Step 7: Test UpdateProgArrayEntry - overwrite slot 0 with pass program
+	fmt.Println("Overwriting slot 0 with pass program...")
+	err = progArrayMap.UpdateProgArrayEntry(0, passFD)
+	if err != nil {
+		fmt.Println("UpdateProgArrayEntry overwrite slot 0 failed:", err)
+		return err
+	}
+
+	val0 = uint32(0)
+	err = progArrayMap.GetMapEntry(uintptr(unsafe.Pointer(&key0)), uintptr(unsafe.Pointer(&val0)))
+	if err != nil {
+		fmt.Println("GetMapEntry for overwritten slot 0 failed:", err)
+		return err
+	}
+	if val0 != passProgInfo.ID {
+		return fmt.Errorf("overwritten slot 0: expected prog ID %d, got %d", passProgInfo.ID, val0)
+	}
+	fmt.Printf("Slot 0 overwrite verified: prog ID %d matches pass program\n", val0)
+
+	// Step 8: Test DeleteProgArrayEntry - clear slot 1
+	fmt.Println("Deleting slot 1...")
+	err = progArrayMap.DeleteProgArrayEntry(1)
+	if err != nil {
+		fmt.Println("DeleteProgArrayEntry slot 1 failed:", err)
+		return err
+	}
+
+	// After deletion, lookup should fail
+	val1 = uint32(0)
+	err = progArrayMap.GetMapEntry(uintptr(unsafe.Pointer(&key1)), uintptr(unsafe.Pointer(&val1)))
+	if err == nil {
+		return fmt.Errorf("slot 1 should be empty after delete, but got prog ID %d", val1)
+	}
+	fmt.Println("Slot 1 deletion verified: lookup correctly returns error")
+
+	// Step 9: Test error cases
+	// Test with wrong map type
+	fmt.Println("Testing error case: wrong map type...")
+	wrongMap := ebpf_maps.BpfMap{MapMetaData: ebpf_maps.CreateEBPFMapInput{
+		Name: "not_prog_array",
+		Type: 1, // BPF_MAP_TYPE_HASH
+	}}
+	err = wrongMap.UpdateProgArrayEntry(0, dropFD)
+	if err == nil {
+		return fmt.Errorf("expected error when using UpdateProgArrayEntry on non-prog-array map")
+	}
+	fmt.Println("  Correctly rejected wrong map type:", err)
+
+	// Test with negative FD
+	fmt.Println("Testing error case: negative FD...")
+	err = progArrayMap.UpdateProgArrayEntry(0, -1)
+	if err == nil {
+		return fmt.Errorf("expected error when using negative FD")
+	}
+	fmt.Println("  Correctly rejected negative FD:", err)
+
+	// Step 10: Test DeleteProgArrayEntry with wrong map type
+	fmt.Println("Testing error case: DeleteProgArrayEntry on wrong map type...")
+	err = wrongMap.DeleteProgArrayEntry(0)
+	if err == nil {
+		return fmt.Errorf("expected error when using DeleteProgArrayEntry on non-prog-array map")
+	}
+	fmt.Println("  Correctly rejected wrong map type for delete:", err)
+
+	// Step 11: Clean up - delete remaining slot
+	fmt.Println("Cleaning up: deleting slot 0...")
+	err = progArrayMap.DeleteProgArrayEntry(0)
+	if err != nil {
+		fmt.Println("DeleteProgArrayEntry cleanup slot 0 failed:", err)
+		return err
+	}
+
+	fmt.Println("Tail call prog array test PASSED!")
 	return nil
 }


### PR DESCRIPTION
*Issue #, if available:* None

### Description

This PR adds **Tail call support and prog array support**, Tail-calls will be useful for features such as support bandwidth enforcement post policy evaluation.

#### What's included

* **Tail call support**

  * Added support for updating and deleting `BPF_MAP_TYPE_PROG_ARRAY` entries through:

    * `UpdateProgArrayEntry()`
    * `DeleteProgArrayEntry()`
  * Performs SDK-side validation to ensure the map type is `BPF_MAP_TYPE_PROG_ARRAY` and program FDs are valid before issuing kernel syscalls.

#### Testing

```
Testing Test tail call prog array
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Found .text section (BPF subprograms) at index 2"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Found PROG Section at Index 3 and Name tc_cls"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Found the progType tc_cls"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Found a relocation section; Info:3; Name: .reltc_cls, Type: SHT_REL; Size: 32"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Found maps Section at Index 5"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Found license - GPL\u0000"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Found PROG Section at Index 7 and Name .debug_loc"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Found the progType .debug_loc"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Not supported program .debug_loc"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Found PROG Section at Index 8 and Name .debug_abbrev"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Found the progType .debug_abbrev"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Not supported program .debug_abbrev"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Found PROG Section at Index 9 and Name .debug_info"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Found the progType .debug_info"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Not supported program .debug_info"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Found a relocation section; Info:9; Name: .rel.debug_info, Type: SHT_REL; Size: 1792"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Found PROG Section at Index 11 and Name .debug_str"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Found the progType .debug_str"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Not supported program .debug_str"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Found PROG Section at Index 12 and Name .BTF"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Found the progType .btf"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Not supported program .btf"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Found a relocation section; Info:12; Name: .rel.BTF, Type: SHT_REL; Size: 32"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Found PROG Section at Index 14 and Name .BTF.ext"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Found the progType .btf.ext"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Not supported program .btf.ext"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Found a relocation section; Info:14; Name: .rel.BTF.ext, Type: SHT_REL; Size: 96"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Found PROG Section at Index 16 and Name .eh_frame"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Found the progType .eh_frame"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Not supported program .eh_frame"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Found a relocation section; Info:16; Name: .rel.eh_frame, Type: SHT_REL; Size: 32"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Found PROG Section at Index 18 and Name .debug_line"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Found the progType .debug_line"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Not supported program .debug_line"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:901","msg":"Found a relocation section; Info:18; Name: .rel.debug_line, Type: SHT_REL; Size: 16"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:907","msg":"Found map name tailcall_map"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:913","msg":"Total maps found - 1"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:913","msg":"Loading maps"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:222","msg":"Calling BPFsys for name tailcall_map mapType 3 keysize 4 valuesize 4 max entries 4 and flags 0"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:222","msg":"Create map done with fd : 19"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"maps/loader.go:265","msg":"Calling BPFsys for FD 19 and Path /sys/fs/bpf/globals/aws/maps/tailcall_tailcall_map"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"maps/loader.go:265","msg":"Pin done with fd : 0 and errno 0"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:976","msg":"Found Identified - tailcall : tailcall_map"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:976","msg":"Adding GLOBAL tailcall_map -> tailcall_map"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:913","msg":"Added map Name tailcall_map and FD 19 to SDK cache"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:733","msg":"Read .text section: 0 bytes (0 insns)"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:733","msg":"No .rel.text relocation section found"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:776","msg":"Loading Program with relocation section; Info:3; Name: .reltc_cls, Type: SHT_REL; Size: 32"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:590","msg":"Relocation section entry: tailcall_map @ 0"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:590","msg":"Relocation section entry: tailcall_map @ 48"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:776","msg":"Applying Relocations.."}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:776","msg":"BPF Instruction code: %!s(uint8=24); offset: 0; imm: 0"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:776","msg":"Map to be relocated; Name: tailcall_map"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:776","msg":"Map found. Replace the offset with corresponding Map FD: 19"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:776","msg":"From data: BPF Instruction code: 24; offset: 0; imm: 19"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:776","msg":"BPF Instruction code: %!s(uint8=24); offset: 0; imm: 0"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:776","msg":"Map to be relocated; Name: tailcall_map"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:776","msg":"Map found. Replace the offset with corresponding Map FD: 19"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:776","msg":"From data: BPF Instruction code: 24; offset: 0; imm: 19"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:919","msg":"Sec 'tc_cls': found program 'handle_egress' at insn offset 6 (48 bytes), code size 6 insns (48 bytes)\n"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:919","msg":"Program 'handle_egress': funcSize=48 sectionLen=96 textLen=0 loadSize=48 insns=6"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:919","msg":"Sec 'tc_cls': found program 'handle_ingress' at insn offset 0 (0 bytes), code size 6 insns (48 bytes)\n"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:919","msg":"Program 'handle_ingress': funcSize=48 sectionLen=96 textLen=0 loadSize=48 insns=6"}
{"level":"info","ts":"2026-07-18T19:03:55.757Z","caller":"elfparser/elf.go:925","msg":"Attempting to load prog: type=tc_cls insnCnt=6 dataLen=48 insDefSize=8"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"elfparser/elf.go:317","msg":"Load prog done with fd : 20 errno: 0 (errno 0) insnCnt: 6 attrSize: 48 progType: 3"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"progs/loader.go:174","msg":"Calling BPFsys for FD 20 and Path /sys/fs/bpf/globals/aws/programs/tailcall_handle_egress"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"progs/loader.go:174","msg":"Pin done with fd : 0 and errno 0"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"elfparser/elf.go:925","msg":"loaded prog with 20"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"elfparser/elf.go:325","msg":"Printing pinpath - /sys/fs/bpf/globals/aws/programs/tailcall_handle_egress "}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"elfparser/elf.go:325","msg":"Got progFD - 21"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"progs/loader.go:461","msg":"TYPE - 3"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"progs/loader.go:461","msg":"Prog Name - \u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"progs/loader.go:461","msg":"Maps linked - 1"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"elfparser/elf.go:925","msg":"Attempting to load prog: type=tc_cls insnCnt=6 dataLen=48 insDefSize=8"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"elfparser/elf.go:317","msg":"Load prog done with fd : 21 errno: 0 (errno 0) insnCnt: 6 attrSize: 48 progType: 3"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"progs/loader.go:174","msg":"Calling BPFsys for FD 21 and Path /sys/fs/bpf/globals/aws/programs/tailcall_handle_ingress"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"progs/loader.go:174","msg":"Pin done with fd : 0 and errno 0"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"elfparser/elf.go:925","msg":"loaded prog with 21"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"elfparser/elf.go:325","msg":"Printing pinpath - /sys/fs/bpf/globals/aws/programs/tailcall_handle_ingress "}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"elfparser/elf.go:325","msg":"Got progFD - 22"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"progs/loader.go:461","msg":"TYPE - 3"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"progs/loader.go:461","msg":"Prog Name - \u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"progs/loader.go:461","msg":"Maps linked - 1"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"progs/loader.go:326","msg":"TYPE - 3"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"progs/loader.go:326","msg":"Prog Name - \u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"progs/loader.go:326","msg":"Maps linked - 1"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"elfparser/elf.go:174","msg":"Found tailcall_map with ID 164 and FD 19"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"progs/loader.go:326","msg":"TYPE - 3"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"progs/loader.go:326","msg":"Prog Name - \u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"progs/loader.go:326","msg":"Maps linked - 1"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"elfparser/elf.go:174","msg":"Found tailcall_map with ID 164 and FD 19"}
Loaded tailcall programs:
  Prog Pin Path:  /sys/fs/bpf/globals/aws/programs/tailcall_handle_egress
  Prog Pin Path:  /sys/fs/bpf/globals/aws/programs/tailcall_handle_ingress
Loaded tailcall maps:
  Map Name:  tailcall_map
Found tailcall_map with FD: 19
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"elfparser/elf.go:901","msg":"Found .text section (BPF subprograms) at index 2"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"elfparser/elf.go:901","msg":"Found PROG Section at Index 3 and Name tc_cls"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"elfparser/elf.go:901","msg":"Found the progType tc_cls"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"elfparser/elf.go:901","msg":"Found license - GPL\u0000"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"elfparser/elf.go:901","msg":"Found PROG Section at Index 5 and Name .debug_abbrev"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"elfparser/elf.go:901","msg":"Found the progType .debug_abbrev"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"elfparser/elf.go:901","msg":"Not supported program .debug_abbrev"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"elfparser/elf.go:901","msg":"Found PROG Section at Index 6 and Name .debug_info"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"elfparser/elf.go:901","msg":"Found the progType .debug_info"}
{"level":"info","ts":"2026-07-18T19:03:55.766Z","caller":"elfparser/elf.go:901","msg":"Not supported program .debug_info"}
{"level":"info","ts":"2026-07-18T19:03:55.767Z","caller":"elfparser/elf.go:901","msg":"Found a relocation section; Info:6; Name: .rel.debug_info, Type: SHT_REL; Size: 1568"}
{"level":"info","ts":"2026-07-18T19:03:55.767Z","caller":"elfparser/elf.go:901","msg":"Found PROG Section at Index 8 and Name .debug_str"}
{"level":"info","ts":"2026-07-18T19:03:55.767Z","caller":"elfparser/elf.go:901","msg":"Found the progType .debug_str"}
{"level":"info","ts":"2026-07-18T19:03:55.767Z","caller":"elfparser/elf.go:901","msg":"Not supported program .debug_str"}
{"level":"info","ts":"2026-07-18T19:03:55.767Z","caller":"elfparser/elf.go:901","msg":"Found PROG Section at Index 9 and Name .BTF"}
{"level":"info","ts":"2026-07-18T19:03:55.767Z","caller":"elfparser/elf.go:901","msg":"Found the progType .btf"}
{"level":"info","ts":"2026-07-18T19:03:55.767Z","caller":"elfparser/elf.go:901","msg":"Not supported program .btf"}
{"level":"info","ts":"2026-07-18T19:03:55.767Z","caller":"elfparser/elf.go:901","msg":"Found a relocation section; Info:9; Name: .rel.BTF, Type: SHT_REL; Size: 16"}
{"level":"info","ts":"2026-07-18T19:03:55.767Z","caller":"elfparser/elf.go:901","msg":"Found PROG Section at Index 11 and Name .BTF.ext"}
{"level":"info","ts":"2026-07-18T19:03:55.767Z","caller":"elfparser/elf.go:901","msg":"Found the progType .btf.ext"}
{"level":"info","ts":"2026-07-18T19:03:55.767Z","caller":"elfparser/elf.go:901","msg":"Not supported program .btf.ext"}
{"level":"info","ts":"2026-07-18T19:03:55.767Z","caller":"elfparser/elf.go:901","msg":"Found a relocation section; Info:11; Name: .rel.BTF.ext, Type: SHT_REL; Size: 64"}
{"level":"info","ts":"2026-07-18T19:03:55.767Z","caller":"elfparser/elf.go:901","msg":"Found PROG Section at Index 13 and Name .eh_frame"}
{"level":"info","ts":"2026-07-18T19:03:55.767Z","caller":"elfparser/elf.go:901","msg":"Found the progType .eh_frame"}
{"level":"info","ts":"2026-07-18T19:03:55.767Z","caller":"elfparser/elf.go:901","msg":"Not supported program .eh_frame"}
{"level":"info","ts":"2026-07-18T19:03:55.767Z","caller":"elfparser/elf.go:901","msg":"Found a relocation section; Info:13; Name: .rel.eh_frame, Type: SHT_REL; Size: 32"}
{"level":"info","ts":"2026-07-18T19:03:55.767Z","caller":"elfparser/elf.go:901","msg":"Found PROG Section at Index 15 and Name .debug_line"}
{"level":"info","ts":"2026-07-18T19:03:55.767Z","caller":"elfparser/elf.go:901","msg":"Found the progType .debug_line"}
{"level":"info","ts":"2026-07-18T19:03:55.767Z","caller":"elfparser/elf.go:901","msg":"Not supported program .debug_line"}
{"level":"info","ts":"2026-07-18T19:03:55.767Z","caller":"elfparser/elf.go:901","msg":"Found a relocation section; Info:15; Name: .rel.debug_line, Type: SHT_REL; Size: 16"}
{"level":"info","ts":"2026-07-18T19:03:55.767Z","caller":"elfparser/elf.go:907","msg":"Bpf file has no map section so skipping parse"}
{"level":"info","ts":"2026-07-18T19:03:55.767Z","caller":"elfparser/elf.go:913","msg":"Total maps found - 0"}
{"level":"info","ts":"2026-07-18T19:03:55.767Z","caller":"elfparser/elf.go:733","msg":"Read .text section: 0 bytes (0 insns)"}
{"level":"info","ts":"2026-07-18T19:03:55.767Z","caller":"elfparser/elf.go:733","msg":"No .rel.text relocation section found"}
{"level":"info","ts":"2026-07-18T19:03:55.767Z","caller":"elfparser/elf.go:919","msg":"Relocation is not needed"}
{"level":"info","ts":"2026-07-18T19:03:55.767Z","caller":"elfparser/elf.go:919","msg":"Sec 'tc_cls': found program 'tailcall_target_drop' at insn offset 0 (0 bytes), code size 2 insns (16 bytes)\n"}
{"level":"info","ts":"2026-07-18T19:03:55.767Z","caller":"elfparser/elf.go:919","msg":"Program 'tailcall_target_drop': funcSize=16 sectionLen=32 textLen=0 loadSize=16 insns=2"}
{"level":"info","ts":"2026-07-18T19:03:55.767Z","caller":"elfparser/elf.go:919","msg":"Sec 'tc_cls': found program 'tailcall_target_pass' at insn offset 2 (16 bytes), code size 2 insns (16 bytes)\n"}
{"level":"info","ts":"2026-07-18T19:03:55.767Z","caller":"elfparser/elf.go:919","msg":"Program 'tailcall_target_pass': funcSize=16 sectionLen=32 textLen=0 loadSize=16 insns=2"}
{"level":"info","ts":"2026-07-18T19:03:55.767Z","caller":"elfparser/elf.go:925","msg":"Attempting to load prog: type=tc_cls insnCnt=2 dataLen=16 insDefSize=8"}
{"level":"info","ts":"2026-07-18T19:03:55.770Z","caller":"elfparser/elf.go:317","msg":"Load prog done with fd : 22 errno: 0 (errno 0) insnCnt: 2 attrSize: 48 progType: 3"}
{"level":"info","ts":"2026-07-18T19:03:55.770Z","caller":"progs/loader.go:174","msg":"Calling BPFsys for FD 22 and Path /sys/fs/bpf/globals/aws/programs/target_tailcall_target_drop"}
{"level":"info","ts":"2026-07-18T19:03:55.770Z","caller":"progs/loader.go:174","msg":"Pin done with fd : 0 and errno 0"}
{"level":"info","ts":"2026-07-18T19:03:55.770Z","caller":"elfparser/elf.go:925","msg":"loaded prog with 22"}
{"level":"info","ts":"2026-07-18T19:03:55.770Z","caller":"elfparser/elf.go:325","msg":"Printing pinpath - /sys/fs/bpf/globals/aws/programs/target_tailcall_target_drop "}
{"level":"info","ts":"2026-07-18T19:03:55.770Z","caller":"elfparser/elf.go:325","msg":"Got progFD - 23"}
{"level":"info","ts":"2026-07-18T19:03:55.770Z","caller":"progs/loader.go:461","msg":"TYPE - 3"}
{"level":"info","ts":"2026-07-18T19:03:55.770Z","caller":"progs/loader.go:461","msg":"Prog Name - \u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"}
{"level":"info","ts":"2026-07-18T19:03:55.770Z","caller":"progs/loader.go:461","msg":"Maps linked - 0"}
{"level":"info","ts":"2026-07-18T19:03:55.770Z","caller":"elfparser/elf.go:925","msg":"Attempting to load prog: type=tc_cls insnCnt=2 dataLen=16 insDefSize=8"}
{"level":"info","ts":"2026-07-18T19:03:55.778Z","caller":"elfparser/elf.go:317","msg":"Load prog done with fd : 23 errno: 0 (errno 0) insnCnt: 2 attrSize: 48 progType: 3"}
{"level":"info","ts":"2026-07-18T19:03:55.778Z","caller":"progs/loader.go:174","msg":"Calling BPFsys for FD 23 and Path /sys/fs/bpf/globals/aws/programs/target_tailcall_target_pass"}
{"level":"info","ts":"2026-07-18T19:03:55.778Z","caller":"progs/loader.go:174","msg":"Pin done with fd : 0 and errno 0"}
{"level":"info","ts":"2026-07-18T19:03:55.778Z","caller":"elfparser/elf.go:925","msg":"loaded prog with 23"}
{"level":"info","ts":"2026-07-18T19:03:55.778Z","caller":"elfparser/elf.go:325","msg":"Printing pinpath - /sys/fs/bpf/globals/aws/programs/target_tailcall_target_pass "}
{"level":"info","ts":"2026-07-18T19:03:55.778Z","caller":"elfparser/elf.go:325","msg":"Got progFD - 24"}
{"level":"info","ts":"2026-07-18T19:03:55.778Z","caller":"progs/loader.go:461","msg":"TYPE - 3"}
{"level":"info","ts":"2026-07-18T19:03:55.778Z","caller":"progs/loader.go:461","msg":"Prog Name - \u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"}
{"level":"info","ts":"2026-07-18T19:03:55.778Z","caller":"progs/loader.go:461","msg":"Maps linked - 0"}
{"level":"info","ts":"2026-07-18T19:03:55.778Z","caller":"progs/loader.go:326","msg":"TYPE - 3"}
{"level":"info","ts":"2026-07-18T19:03:55.778Z","caller":"progs/loader.go:326","msg":"Prog Name - \u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"}
{"level":"info","ts":"2026-07-18T19:03:55.778Z","caller":"progs/loader.go:326","msg":"Maps linked - 0"}
{"level":"info","ts":"2026-07-18T19:03:55.778Z","caller":"progs/loader.go:326","msg":"TYPE - 3"}
{"level":"info","ts":"2026-07-18T19:03:55.778Z","caller":"progs/loader.go:326","msg":"Prog Name - \u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"}
{"level":"info","ts":"2026-07-18T19:03:55.778Z","caller":"progs/loader.go:326","msg":"Maps linked - 0"}
Loaded target programs:
  Target Prog Pin Path:  /sys/fs/bpf/globals/aws/programs/target_tailcall_target_drop
  Target Prog Pin Path:  /sys/fs/bpf/globals/aws/programs/target_tailcall_target_pass
  Drop target FD: 22
  Pass target FD: 23
Inserting drop program into slot 0...
Inserting pass program into slot 1...
{"level":"info","ts":"2026-07-18T19:03:55.778Z","caller":"test/main.go:562","msg":"TYPE - 3"}
{"level":"info","ts":"2026-07-18T19:03:55.778Z","caller":"test/main.go:562","msg":"Prog Name - \u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"}
{"level":"info","ts":"2026-07-18T19:03:55.778Z","caller":"test/main.go:562","msg":"Maps linked - 0"}
{"level":"info","ts":"2026-07-18T19:03:55.778Z","caller":"test/main.go:567","msg":"TYPE - 3"}
{"level":"info","ts":"2026-07-18T19:03:55.778Z","caller":"test/main.go:567","msg":"Prog Name - \u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"}
{"level":"info","ts":"2026-07-18T19:03:55.778Z","caller":"test/main.go:567","msg":"Maps linked - 0"}
Slot 0 verified: prog ID 315 matches drop program
Slot 1 verified: prog ID 316 matches pass program
Overwriting slot 0 with pass program...
Slot 0 overwrite verified: prog ID 316 matches pass program
Deleting slot 1...
{"level":"error","ts":"2026-07-18T19:03:55.853Z","caller":"test/main.go:626","msg":"unable to get map entry and ret -1 and err no such file or directory"}
Slot 1 deletion verified: lookup correctly returns error
Testing error case: wrong map type...
  Correctly rejected wrong map type: UpdateProgArrayEntry: map "not_prog_array" is type 1, not BPF_MAP_TYPE_PROG_ARRAY
Testing error case: negative FD...
  Correctly rejected negative FD: UpdateProgArrayEntry: invalid program FD -1
Testing error case: DeleteProgArrayEntry on wrong map type...
  Correctly rejected wrong map type for delete: DeleteProgArrayEntry: map "not_prog_array" is type 1, not BPF_MAP_TYPE_PROG_ARRAY
Cleaning up: deleting slot 0...
Tail call prog array test PASSED!
SUCCESS!
Let's unmount BPF FS
===========================================================
                   TESTING SUMMARY                         
===========================================================
                   TestCase|Result
              Test loading TC filter|SUCCESS
   Test loading Maps without Program|SUCCESS
         Test loading Map operations|SUCCESS
            Test bulk Map operations|SUCCESS
              Test updating Map size|SUCCESS
    Test bulk refresh Map operations|SUCCESS
           Test tail call prog array|SUCCESS
                Test loading Program|SUCCESS
             Test loading V6 Program|SUCCESS
===========================================================

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
